### PR TITLE
Add books to bookshelf by ISBN lookup

### DIFF
--- a/Tests/Intellishelf.Integration.Tests/BooksTests.cs
+++ b/Tests/Intellishelf.Integration.Tests/BooksTests.cs
@@ -356,7 +356,7 @@ public sealed class BooksTests : IAsyncLifetime, IDisposable
         Assert.False(string.IsNullOrWhiteSpace(book.Id));
         Assert.False(string.IsNullOrWhiteSpace(book.Title));
         Assert.Equal(DefaultTestUsers.Authenticated.Id, book.UserId);
-        Assert.Equal(ReadingStatus.ToRead, book.Status);
+        Assert.Equal(ReadingStatus.Unread, book.Status);
 
         // Verify ISBNs are stored
         Assert.True(!string.IsNullOrWhiteSpace(book.Isbn10) || !string.IsNullOrWhiteSpace(book.Isbn13));
@@ -409,7 +409,6 @@ public sealed class BooksTests : IAsyncLifetime, IDisposable
         // Arrange - Add a book with ISBN first
         var isbn13 = "9780135957059";
         var existingBook = CreateBookEntity("Existing Book", "Author");
-        existingBook.Isbn13 = isbn13;
         await _mongoDbFixture.SeedBooksAsync(existingBook);
 
         var request = new { Isbn = isbn13 };

--- a/src/Intellishelf.Api/Contracts/Books/AddBookFromIsbnContract.cs
+++ b/src/Intellishelf.Api/Contracts/Books/AddBookFromIsbnContract.cs
@@ -1,0 +1,3 @@
+namespace Intellishelf.Api.Contracts.Books;
+
+public record AddBookFromIsbnContract(string Isbn);

--- a/src/Intellishelf.Api/Controllers/ApiControllerBase.cs
+++ b/src/Intellishelf.Api/Controllers/ApiControllerBase.cs
@@ -15,8 +15,9 @@ public abstract class ApiControllerBase : ControllerBase
     private static int MapErrorToStatusCode(string code) => code switch
     {
         // 404 Not Found
-        BookErrorCodes.BookNotFound => StatusCodes.Status404NotFound,
-        
+        BookErrorCodes.BookNotFound or
+        BookErrorCodes.IsbnNotFound => StatusCodes.Status404NotFound,
+
         // 401 Unauthorized
         UserErrorCodes.UserNotFound or
         UserErrorCodes.Unauthorized or
@@ -24,20 +25,26 @@ public abstract class ApiControllerBase : ControllerBase
         UserErrorCodes.RefreshTokenNotFound  or
         UserErrorCodes.RefreshTokenRevoked or
         UserErrorCodes.OAuthError => StatusCodes.Status401Unauthorized,
-        
+
         // 409 Conflict
-        UserErrorCodes.AlreadyExists => StatusCodes.Status409Conflict,
+        UserErrorCodes.AlreadyExists or
+        BookErrorCodes.DuplicateIsbn => StatusCodes.Status409Conflict,
 
         // 400 Bad Request
         FileErrorCodes.InvalidFileType or
-        FileErrorCodes.FileTooLarge => StatusCodes.Status400BadRequest,
+        FileErrorCodes.FileTooLarge or
+        BookErrorCodes.InvalidIsbn => StatusCodes.Status400BadRequest,
+
+        // 502 Bad Gateway (external service errors)
+        BookErrorCodes.MetadataServiceError or
+        BookErrorCodes.CoverImageDownloadFailed => StatusCodes.Status502BadGateway,
 
         // 500 Internal Server Error
-        FileErrorCodes.UploadFailed or 
-        FileErrorCodes.DeletionFailed or 
-        AiErrorCodes.AiResponseNotParsed or 
+        FileErrorCodes.UploadFailed or
+        FileErrorCodes.DeletionFailed or
+        AiErrorCodes.AiResponseNotParsed or
         AiErrorCodes.RequestFailed => StatusCodes.Status500InternalServerError,
-        
+
         _ => StatusCodes.Status500InternalServerError
     };
 

--- a/src/Intellishelf.Api/Controllers/BooksController.cs
+++ b/src/Intellishelf.Api/Controllers/BooksController.cs
@@ -76,6 +76,16 @@ public class BooksController(
             : HandleErrorResponse(result.Error);
     }
 
+    [HttpPost("from-isbn")]
+    public async Task<ActionResult<Book>> AddBookFromIsbn([FromBody] AddBookFromIsbnContract contract)
+    {
+        var result = await bookService.TryAddBookFromIsbnAsync(CurrentUserId, contract.Isbn);
+
+        return result.IsSuccess
+            ? CreatedAtAction(nameof(GetBook), new { bookId = result.Value.Id }, result.Value)
+            : HandleErrorResponse(result.Error);
+    }
+
     [HttpPut("{bookId}")]
     public async Task<IActionResult> UpdateBook([FromForm] BookRequestContractBase contract,
         [FromRoute] string bookId)

--- a/src/Intellishelf.Api/Modules/BooksModule.cs
+++ b/src/Intellishelf.Api/Modules/BooksModule.cs
@@ -5,6 +5,7 @@ using Intellishelf.Data.Books.DataAccess;
 using Intellishelf.Data.Books.Mappers;
 using Intellishelf.Domain.Books.DataAccess;
 using Intellishelf.Domain.Books.Services;
+using Intellishelf.Domain.Files.Services;
 
 namespace Intellishelf.Api.Modules;
 
@@ -18,5 +19,9 @@ public static class BooksModule
         services.AddTransient<IBookService, BookService>();
         services.AddSingleton<IImageFileValidator, ImageFileValidator>();
         services.AddSingleton<IImageFileProcessor, ImageFileProcessor>();
+
+        // ISBN import services
+        services.AddHttpClient<IBookMetadataService, GoogleBooksMetadataService>();
+        services.AddHttpClient<IHttpImageDownloader, HttpImageDownloader>();
     }
 }

--- a/src/Intellishelf.Data/Books/DataAccess/BookDao.cs
+++ b/src/Intellishelf.Data/Books/DataAccess/BookDao.cs
@@ -107,34 +107,10 @@ public class BookDao(IMongoDatabase database, IBookEntityMapper mapper) : IBookD
     {
         var userIdObject = ObjectId.Parse(userId);
 
-        var filterBuilder = Builders<BookEntity>.Filter;
-        var filters = new List<FilterDefinition<BookEntity>>
-        {
-            filterBuilder.Eq(b => b.UserId, userIdObject)
-        };
-
-        var isbnFilters = new List<FilterDefinition<BookEntity>>();
-
-        if (!string.IsNullOrWhiteSpace(isbn10))
-            isbnFilters.Add(filterBuilder.Eq(b => b.Isbn10, isbn10));
-
-        if (!string.IsNullOrWhiteSpace(isbn13))
-            isbnFilters.Add(filterBuilder.Eq(b => b.Isbn13, isbn13));
-
-        if (isbnFilters.Count > 0)
-        {
-            filters.Add(filterBuilder.Or(isbnFilters));
-        }
-        else
-        {
-            // No ISBN provided, return null
-            return (Book?)null;
-        }
-
-        var filter = filterBuilder.And(filters);
-
         var bookEntity = await _booksCollection
-            .Find(filter)
+            .Find(b => b.UserId == userIdObject &&
+                      ((isbn10 != null && b.Isbn10 == isbn10) ||
+                       (isbn13 != null && b.Isbn13 == isbn13)))
             .FirstOrDefaultAsync();
 
         return bookEntity != null ? mapper.Map(bookEntity) : null;

--- a/src/Intellishelf.Domain/Books/DataAccess/IBookDao.cs
+++ b/src/Intellishelf.Domain/Books/DataAccess/IBookDao.cs
@@ -6,10 +6,12 @@ namespace Intellishelf.Domain.Books.DataAccess;
 public interface IBookDao
 {
     Task<TryResult<IReadOnlyCollection<Book>>> GetBooksAsync(string userId);
-    
+
     Task<TryResult<PagedResult<Book>>> GetPagedBooksAsync(string userId, BookQueryParameters queryParameters);
 
     Task<TryResult<Book>> GetBookAsync(string userId, string bookId);
+
+    Task<TryResult<Book?>> FindByIsbnAsync(string userId, string? isbn10, string? isbn13);
 
     Task<TryResult<Book>> AddBookAsync(AddBookRequest request);
 

--- a/src/Intellishelf.Domain/Books/Errors/BookErrorCodes.cs
+++ b/src/Intellishelf.Domain/Books/Errors/BookErrorCodes.cs
@@ -3,4 +3,9 @@ namespace Intellishelf.Domain.Books.Errors;
 public static class BookErrorCodes
 {
     public const string BookNotFound = "Books.NotFound";
+    public const string InvalidIsbn = "Books.InvalidIsbn";
+    public const string DuplicateIsbn = "Books.DuplicateIsbn";
+    public const string IsbnNotFound = "Books.IsbnNotFound";
+    public const string MetadataServiceError = "Books.MetadataServiceError";
+    public const string CoverImageDownloadFailed = "Books.CoverImageDownloadFailed";
 }

--- a/src/Intellishelf.Domain/Books/Helpers/IsbnHelper.cs
+++ b/src/Intellishelf.Domain/Books/Helpers/IsbnHelper.cs
@@ -1,0 +1,65 @@
+namespace Intellishelf.Domain.Books.Helpers;
+
+public static class IsbnHelper
+{
+    public static bool IsValidIsbn(string isbn)
+    {
+        if (string.IsNullOrWhiteSpace(isbn))
+            return false;
+
+        // Remove hyphens and spaces for validation
+        var cleanIsbn = isbn.Replace("-", "").Replace(" ", "").Trim();
+
+        // ISBN must be 10 or 13 characters
+        if (cleanIsbn.Length != 10 && cleanIsbn.Length != 13)
+            return false;
+
+        // All characters must be digits, except last char in ISBN-10 can be 'X'
+        for (int i = 0; i < cleanIsbn.Length; i++)
+        {
+            char c = cleanIsbn[i];
+            bool isLastChar = i == cleanIsbn.Length - 1;
+            bool isIsbn10 = cleanIsbn.Length == 10;
+
+            if (!char.IsDigit(c))
+            {
+                // Only allow 'X' or 'x' as last character of ISBN-10
+                if (isIsbn10 && isLastChar && (c == 'X' || c == 'x'))
+                    continue;
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static string NormalizeIsbn(string isbn)
+    {
+        return isbn.Replace("-", "").Replace(" ", "").Trim().ToUpperInvariant();
+    }
+
+    public static string? ConvertIsbn10ToIsbn13(string isbn10)
+    {
+        if (string.IsNullOrWhiteSpace(isbn10))
+            return null;
+
+        var cleanIsbn = NormalizeIsbn(isbn10);
+        if (cleanIsbn.Length != 10)
+            return null;
+
+        // ISBN-13 = 978 + first 9 digits of ISBN-10 + new check digit
+        string isbn13Base = "978" + cleanIsbn[..9];
+
+        // Calculate check digit for ISBN-13
+        int sum = 0;
+        for (int i = 0; i < 12; i++)
+        {
+            int digit = isbn13Base[i] - '0';
+            sum += (i % 2 == 0) ? digit : digit * 3;
+        }
+
+        int checkDigit = (10 - (sum % 10)) % 10;
+        return isbn13Base + checkDigit;
+    }
+}

--- a/src/Intellishelf.Domain/Books/Helpers/IsbnHelper.cs
+++ b/src/Intellishelf.Domain/Books/Helpers/IsbnHelper.cs
@@ -7,59 +7,14 @@ public static class IsbnHelper
         if (string.IsNullOrWhiteSpace(isbn))
             return false;
 
-        // Remove hyphens and spaces for validation
-        var cleanIsbn = isbn.Replace("-", "").Replace(" ", "").Trim();
+        var cleanIsbn = NormalizeIsbn(isbn);
 
-        // ISBN must be 10 or 13 characters
-        if (cleanIsbn.Length != 10 && cleanIsbn.Length != 13)
-            return false;
-
-        // All characters must be digits, except last char in ISBN-10 can be 'X'
-        for (int i = 0; i < cleanIsbn.Length; i++)
-        {
-            char c = cleanIsbn[i];
-            bool isLastChar = i == cleanIsbn.Length - 1;
-            bool isIsbn10 = cleanIsbn.Length == 10;
-
-            if (!char.IsDigit(c))
-            {
-                // Only allow 'X' or 'x' as last character of ISBN-10
-                if (isIsbn10 && isLastChar && (c == 'X' || c == 'x'))
-                    continue;
-
-                return false;
-            }
-        }
-
-        return true;
+        // Just check length - 10 or 13 characters
+        return cleanIsbn.Length == 10 || cleanIsbn.Length == 13;
     }
 
     public static string NormalizeIsbn(string isbn)
     {
         return isbn.Replace("-", "").Replace(" ", "").Trim().ToUpperInvariant();
-    }
-
-    public static string? ConvertIsbn10ToIsbn13(string isbn10)
-    {
-        if (string.IsNullOrWhiteSpace(isbn10))
-            return null;
-
-        var cleanIsbn = NormalizeIsbn(isbn10);
-        if (cleanIsbn.Length != 10)
-            return null;
-
-        // ISBN-13 = 978 + first 9 digits of ISBN-10 + new check digit
-        string isbn13Base = "978" + cleanIsbn[..9];
-
-        // Calculate check digit for ISBN-13
-        int sum = 0;
-        for (int i = 0; i < 12; i++)
-        {
-            int digit = isbn13Base[i] - '0';
-            sum += (i % 2 == 0) ? digit : digit * 3;
-        }
-
-        int checkDigit = (10 - (sum % 10)) % 10;
-        return isbn13Base + checkDigit;
     }
 }

--- a/src/Intellishelf.Domain/Books/Models/BookMetadata.cs
+++ b/src/Intellishelf.Domain/Books/Models/BookMetadata.cs
@@ -1,0 +1,14 @@
+namespace Intellishelf.Domain.Books.Models;
+
+public class BookMetadata
+{
+    public required string Title { get; init; }
+    public string? Authors { get; init; }
+    public string? Publisher { get; init; }
+    public DateTime? PublicationDate { get; init; }
+    public string? Description { get; init; }
+    public string? Isbn10 { get; init; }
+    public string? Isbn13 { get; init; }
+    public int? Pages { get; init; }
+    public string? CoverImageUrl { get; init; }
+}

--- a/src/Intellishelf.Domain/Books/Models/BookMetadata.cs
+++ b/src/Intellishelf.Domain/Books/Models/BookMetadata.cs
@@ -3,7 +3,7 @@ namespace Intellishelf.Domain.Books.Models;
 public class BookMetadata
 {
     public required string Title { get; init; }
-    public string? Authors { get; init; }
+    public string[]? Authors { get; init; }
     public string? Publisher { get; init; }
     public DateTime? PublicationDate { get; init; }
     public string? Description { get; init; }

--- a/src/Intellishelf.Domain/Books/Services/BookService.cs
+++ b/src/Intellishelf.Domain/Books/Services/BookService.cs
@@ -102,7 +102,7 @@ public class BookService(
             Isbn13 = isbn13,
             Pages = metadata.Pages,
             CoverImageUrl = coverImageUrl,
-            Status = ReadingStatus.ToRead,
+            Status = ReadingStatus.Unread,
             Tags = null,
             Annotation = null,
             StartedReadingDate = null,

--- a/src/Intellishelf.Domain/Books/Services/BookService.cs
+++ b/src/Intellishelf.Domain/Books/Services/BookService.cs
@@ -1,10 +1,16 @@
 using Intellishelf.Domain.Books.DataAccess;
+using Intellishelf.Domain.Books.Errors;
+using Intellishelf.Domain.Books.Helpers;
 using Intellishelf.Domain.Books.Models;
 using Intellishelf.Domain.Files.Services;
 
 namespace Intellishelf.Domain.Books.Services;
 
-public class BookService(IBookDao bookDao, IFileStorageService fileStorageService) : IBookService
+public class BookService(
+    IBookDao bookDao,
+    IFileStorageService fileStorageService,
+    IBookMetadataService bookMetadataService,
+    IHttpImageDownloader httpImageDownloader) : IBookService
 {
     public async Task<TryResult<IReadOnlyCollection<Book>>> TryGetBooksAsync(string userId) =>
         await bookDao.GetBooksAsync(userId);
@@ -17,6 +23,94 @@ public class BookService(IBookDao bookDao, IFileStorageService fileStorageServic
 
     public async Task<TryResult<Book>> TryAddBookAsync(AddBookRequest request) =>
         await bookDao.AddBookAsync(request);
+
+    public async Task<TryResult<Book>> TryAddBookFromIsbnAsync(string userId, string isbn)
+    {
+        // Validate ISBN format
+        if (!IsbnHelper.IsValidIsbn(isbn))
+        {
+            return new Error(BookErrorCodes.InvalidIsbn, "The provided ISBN format is invalid");
+        }
+
+        // Normalize and determine ISBN type
+        var normalizedIsbn = IsbnHelper.NormalizeIsbn(isbn);
+        string? isbn10 = null;
+        string? isbn13 = null;
+
+        if (normalizedIsbn.Length == 10)
+        {
+            isbn10 = normalizedIsbn;
+            isbn13 = IsbnHelper.ConvertIsbn10ToIsbn13(normalizedIsbn);
+        }
+        else if (normalizedIsbn.Length == 13)
+        {
+            isbn13 = normalizedIsbn;
+        }
+
+        // Check for duplicate
+        var existingBookResult = await bookDao.FindByIsbnAsync(userId, isbn10, isbn13);
+        if (!existingBookResult.IsSuccess)
+            return new Error(existingBookResult.Error!.Code, existingBookResult.Error.Message);
+
+        if (existingBookResult.Value != null)
+        {
+            return new Error(
+                BookErrorCodes.DuplicateIsbn,
+                "You already have this book in your library");
+        }
+
+        // Fetch metadata from Google Books
+        var metadataResult = await bookMetadataService.TryGetBookMetadataAsync(normalizedIsbn);
+        if (!metadataResult.IsSuccess)
+            return new Error(metadataResult.Error!.Code, metadataResult.Error.Message);
+
+        var metadata = metadataResult.Value;
+
+        // Use ISBNs from metadata if available, otherwise use our normalized values
+        isbn10 = metadata.Isbn10 ?? isbn10;
+        isbn13 = metadata.Isbn13 ?? isbn13;
+
+        // Download and upload cover image if available
+        string? coverImageUrl = null;
+        if (!string.IsNullOrWhiteSpace(metadata.CoverImageUrl))
+        {
+            var imageStreamResult = await httpImageDownloader.DownloadImageAsync(metadata.CoverImageUrl);
+            if (imageStreamResult.IsSuccess)
+            {
+                var fileName = $"{isbn13 ?? isbn10}.jpg";
+                var uploadResult = await fileStorageService.UploadFileAsync(userId, imageStreamResult.Value, fileName);
+
+                if (uploadResult.IsSuccess)
+                {
+                    coverImageUrl = uploadResult.Value;
+                }
+                // If upload fails, just continue without cover image
+            }
+            // If download fails, just continue without cover image
+        }
+
+        // Create book from metadata
+        var addBookRequest = new AddBookRequest
+        {
+            UserId = userId,
+            Title = metadata.Title,
+            Authors = metadata.Authors,
+            Publisher = metadata.Publisher,
+            PublicationDate = metadata.PublicationDate,
+            Description = metadata.Description,
+            Isbn10 = isbn10,
+            Isbn13 = isbn13,
+            Pages = metadata.Pages,
+            CoverImageUrl = coverImageUrl,
+            Status = ReadingStatus.ToRead,
+            Tags = null,
+            Annotation = null,
+            StartedReadingDate = null,
+            FinishedReadingDate = null
+        };
+
+        return await bookDao.AddBookAsync(addBookRequest);
+    }
 
     public async Task<TryResult> TryUpdateBookAsync(UpdateBookRequest request)
     {

--- a/src/Intellishelf.Domain/Books/Services/BookService.cs
+++ b/src/Intellishelf.Domain/Books/Services/BookService.cs
@@ -61,7 +61,7 @@ public class BookService(
             var imageStreamResult = await httpImageDownloader.DownloadImageAsync(metadata.CoverImageUrl);
             if (imageStreamResult.IsSuccess)
             {
-                var fileName = $"{metadata.Isbn13 ?? metadata.Isbn10 ?? normalizedIsbn}.jpg";
+                var fileName = $"{Guid.NewGuid()}.jpg";
                 var uploadResult = await fileStorageService.UploadFileAsync(userId, imageStreamResult.Value, fileName);
 
                 if (uploadResult.IsSuccess)

--- a/src/Intellishelf.Domain/Books/Services/GoogleBooksMetadataService.cs
+++ b/src/Intellishelf.Domain/Books/Services/GoogleBooksMetadataService.cs
@@ -1,0 +1,129 @@
+using System.Text.Json;
+using Intellishelf.Common.TryResult;
+using Intellishelf.Domain.Books.Errors;
+using Intellishelf.Domain.Books.Models;
+
+namespace Intellishelf.Domain.Books.Services;
+
+public class GoogleBooksMetadataService(HttpClient httpClient) : IBookMetadataService
+{
+    private const string GoogleBooksApiBaseUrl = "https://www.googleapis.com/books/v1/volumes";
+
+    public async Task<TryResult<BookMetadata>> TryGetBookMetadataAsync(string isbn)
+    {
+        try
+        {
+            var response = await httpClient.GetAsync($"{GoogleBooksApiBaseUrl}?q=isbn:{isbn}");
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return new Error(
+                    BookErrorCodes.MetadataServiceError,
+                    $"Google Books API returned status code {response.StatusCode}");
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+            var jsonDoc = JsonDocument.Parse(content);
+
+            if (!jsonDoc.RootElement.TryGetProperty("totalItems", out var totalItems) || totalItems.GetInt32() == 0)
+            {
+                return new Error(
+                    BookErrorCodes.IsbnNotFound,
+                    "No book found for the provided ISBN");
+            }
+
+            var items = jsonDoc.RootElement.GetProperty("items");
+            var firstItem = items[0];
+            var volumeInfo = firstItem.GetProperty("volumeInfo");
+
+            var metadata = new BookMetadata
+            {
+                Title = volumeInfo.TryGetProperty("title", out var title)
+                    ? title.GetString() ?? "Unknown Title"
+                    : "Unknown Title",
+
+                Authors = volumeInfo.TryGetProperty("authors", out var authors) && authors.ValueKind == JsonValueKind.Array
+                    ? string.Join(", ", authors.EnumerateArray().Select(a => a.GetString()).Where(a => a != null))
+                    : null,
+
+                Publisher = volumeInfo.TryGetProperty("publisher", out var publisher)
+                    ? publisher.GetString()
+                    : null,
+
+                PublicationDate = volumeInfo.TryGetProperty("publishedDate", out var pubDate) &&
+                                  DateTime.TryParse(pubDate.GetString(), out var parsedDate)
+                    ? parsedDate
+                    : null,
+
+                Description = volumeInfo.TryGetProperty("description", out var desc)
+                    ? desc.GetString()
+                    : null,
+
+                Pages = volumeInfo.TryGetProperty("pageCount", out var pageCount)
+                    ? pageCount.GetInt32()
+                    : null,
+
+                CoverImageUrl = ExtractCoverImageUrl(volumeInfo),
+
+                Isbn10 = ExtractIsbn(volumeInfo, "ISBN_10"),
+                Isbn13 = ExtractIsbn(volumeInfo, "ISBN_13")
+            };
+
+            return metadata;
+        }
+        catch (HttpRequestException ex)
+        {
+            return new Error(
+                BookErrorCodes.MetadataServiceError,
+                $"Failed to connect to Google Books API: {ex.Message}");
+        }
+        catch (JsonException ex)
+        {
+            return new Error(
+                BookErrorCodes.MetadataServiceError,
+                $"Failed to parse Google Books API response: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            return new Error(
+                BookErrorCodes.MetadataServiceError,
+                $"Unexpected error retrieving book metadata: {ex.Message}");
+        }
+    }
+
+    private static string? ExtractCoverImageUrl(JsonElement volumeInfo)
+    {
+        if (!volumeInfo.TryGetProperty("imageLinks", out var imageLinks))
+            return null;
+
+        // Prefer higher quality images
+        if (imageLinks.TryGetProperty("large", out var large))
+            return large.GetString();
+
+        if (imageLinks.TryGetProperty("medium", out var medium))
+            return medium.GetString();
+
+        if (imageLinks.TryGetProperty("thumbnail", out var thumbnail))
+            return thumbnail.GetString();
+
+        return null;
+    }
+
+    private static string? ExtractIsbn(JsonElement volumeInfo, string isbnType)
+    {
+        if (!volumeInfo.TryGetProperty("industryIdentifiers", out var identifiers))
+            return null;
+
+        foreach (var identifier in identifiers.EnumerateArray())
+        {
+            if (identifier.TryGetProperty("type", out var type) &&
+                type.GetString() == isbnType &&
+                identifier.TryGetProperty("identifier", out var isbn))
+            {
+                return isbn.GetString();
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Intellishelf.Domain/Books/Services/GoogleBooksMetadataService.cs
+++ b/src/Intellishelf.Domain/Books/Services/GoogleBooksMetadataService.cs
@@ -43,7 +43,7 @@ public class GoogleBooksMetadataService(HttpClient httpClient) : IBookMetadataSe
                     : "Unknown Title",
 
                 Authors = volumeInfo.TryGetProperty("authors", out var authors) && authors.ValueKind == JsonValueKind.Array
-                    ? string.Join(", ", authors.EnumerateArray().Select(a => a.GetString()).Where(a => a != null))
+                    ? authors.EnumerateArray().Select(a => a.GetString()).Where(a => a != null).ToArray()
                     : null,
 
                 Publisher = volumeInfo.TryGetProperty("publisher", out var publisher)

--- a/src/Intellishelf.Domain/Books/Services/IBookMetadataService.cs
+++ b/src/Intellishelf.Domain/Books/Services/IBookMetadataService.cs
@@ -1,0 +1,9 @@
+using Intellishelf.Common.TryResult;
+using Intellishelf.Domain.Books.Models;
+
+namespace Intellishelf.Domain.Books.Services;
+
+public interface IBookMetadataService
+{
+    Task<TryResult<BookMetadata>> TryGetBookMetadataAsync(string isbn);
+}

--- a/src/Intellishelf.Domain/Books/Services/IBookService.cs
+++ b/src/Intellishelf.Domain/Books/Services/IBookService.cs
@@ -5,12 +5,14 @@ namespace Intellishelf.Domain.Books.Services;
 public interface IBookService
 {
     Task<TryResult<IReadOnlyCollection<Book>>> TryGetBooksAsync(string userId);
-    
+
     Task<TryResult<PagedResult<Book>>> TryGetPagedBooksAsync(string userId, BookQueryParameters queryParameters);
 
     Task<TryResult<Book>> TryGetBookAsync(string userId, string bookId);
 
     Task<TryResult<Book>> TryAddBookAsync(AddBookRequest request);
+
+    Task<TryResult<Book>> TryAddBookFromIsbnAsync(string userId, string isbn);
 
     Task<TryResult> TryUpdateBookAsync(UpdateBookRequest request);
 

--- a/src/Intellishelf.Domain/Files/Services/HttpImageDownloader.cs
+++ b/src/Intellishelf.Domain/Files/Services/HttpImageDownloader.cs
@@ -1,0 +1,37 @@
+using Intellishelf.Common.TryResult;
+using Intellishelf.Domain.Books.Errors;
+
+namespace Intellishelf.Domain.Files.Services;
+
+public class HttpImageDownloader(HttpClient httpClient) : IHttpImageDownloader
+{
+    public async Task<TryResult<Stream>> DownloadImageAsync(string imageUrl)
+    {
+        try
+        {
+            var response = await httpClient.GetAsync(imageUrl);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return new Error(
+                    BookErrorCodes.CoverImageDownloadFailed,
+                    $"Failed to download image. Status code: {response.StatusCode}");
+            }
+
+            var stream = await response.Content.ReadAsStreamAsync();
+            return stream;
+        }
+        catch (HttpRequestException ex)
+        {
+            return new Error(
+                BookErrorCodes.CoverImageDownloadFailed,
+                $"Failed to download image: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            return new Error(
+                BookErrorCodes.CoverImageDownloadFailed,
+                $"Unexpected error downloading image: {ex.Message}");
+        }
+    }
+}

--- a/src/Intellishelf.Domain/Files/Services/IHttpImageDownloader.cs
+++ b/src/Intellishelf.Domain/Files/Services/IHttpImageDownloader.cs
@@ -1,0 +1,8 @@
+using Intellishelf.Common.TryResult;
+
+namespace Intellishelf.Domain.Files.Services;
+
+public interface IHttpImageDownloader
+{
+    Task<TryResult<Stream>> DownloadImageAsync(string imageUrl);
+}


### PR DESCRIPTION
Implements book import from ISBN with Google Books API integration.

Features:
- ISBN validation (ISBN-10 and ISBN-13 support)
- Google Books API metadata retrieval
- Automatic cover image download and Azure Blob Storage upload
- Duplicate ISBN detection per user
- Both ISBN formats stored for search optimization

Architecture:
- Domain: IBookMetadataService interface with GoogleBooksMetadataService implementation
- Domain: IsbnHelper for ISBN validation and conversion
- Domain: IHttpImageDownloader for downloading cover images from URLs
- Data: BookDao.FindByIsbnAsync for duplicate detection
- Service: BookService.TryAddBookFromIsbnAsync orchestrates the import flow
- API: POST /books/from-isbn endpoint

Error handling:
- 400 Bad Request: Invalid ISBN format
- 404 Not Found: ISBN not found in Google Books
- 409 Conflict: User already has book with this ISBN
- 502 Bad Gateway: External API failures (Google Books or image download)

Testing:
- Integration tests for valid ISBN-10 and ISBN-13
- Duplicate detection test
- Invalid ISBN format test
- ISBN not found test