### PR TITLE
Add simple chatting endpoint to backend

### DIFF
--- a/src/Intellishelf.Domain/Chat/Models/ChatStreamChunk.cs
+++ b/src/Intellishelf.Domain/Chat/Models/ChatStreamChunk.cs
@@ -1,0 +1,8 @@
+namespace Intellishelf.Domain.Chat.Models;
+
+public class ChatStreamChunk
+{
+    public string Content { get; init; } = string.Empty;
+    public bool Done { get; init; }
+    public string? Error { get; init; }
+}

--- a/src/Intellishelf.Domain/Chat/Services/ChatService.cs
+++ b/src/Intellishelf.Domain/Chat/Services/ChatService.cs
@@ -75,7 +75,7 @@ public class ChatService(IBookDao bookDao, ChatClient chatClient) : IChatService
         messages.Add(OpenAIChatMessage.CreateUserMessage(request.Message));
 
         // Return the streaming enumerable - errors after this point are mid-stream
-        return StreamOpenAiResponseAsync(messages);
+        return TryResult.Success(StreamOpenAiResponseAsync(messages));
     }
 
     private async IAsyncEnumerable<ChatStreamChunk> StreamOpenAiResponseAsync(List<OpenAIChatMessage> messages)

--- a/src/Intellishelf.Domain/Chat/Services/IChatService.cs
+++ b/src/Intellishelf.Domain/Chat/Services/IChatService.cs
@@ -4,5 +4,5 @@ namespace Intellishelf.Domain.Chat.Services;
 
 public interface IChatService
 {
-    IAsyncEnumerable<ChatStreamChunk> ChatStreamAsync(string userId, ChatRequest request);
+    Task<TryResult<IAsyncEnumerable<ChatStreamChunk>>> ChatStreamAsync(string userId, ChatRequest request);
 }

--- a/src/Intellishelf.Domain/Chat/Services/IChatService.cs
+++ b/src/Intellishelf.Domain/Chat/Services/IChatService.cs
@@ -4,5 +4,5 @@ namespace Intellishelf.Domain.Chat.Services;
 
 public interface IChatService
 {
-    Task<TryResult<ChatResponse>> ChatAsync(string userId, ChatRequest request);
+    IAsyncEnumerable<ChatStreamChunk> ChatStreamAsync(string userId, ChatRequest request);
 }


### PR DESCRIPTION
- Replace /chat endpoint with /chat-stream using Server-Sent Events
- Add ChatStreamChunk model for streaming responses
- Implement ChatStreamAsync using OpenAI streaming API
- Stream tokens in real-time with proper SSE format
- Handle client disconnection with cancellation tokens
- Support error handling mid-stream