### PR TITLE
Create MCP server with .NET

### DIFF
--- a/src/Intellishelf.Api/Intellishelf.Api.csproj
+++ b/src/Intellishelf.Api/Intellishelf.Api.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.9" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
+        <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.4.0-preview.3" />
         <PackageReference Include="MongoDB.Driver" Version="3.2.1" />
         <PackageReference Include="OpenAI" Version="2.7.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.6.1" />

--- a/src/Intellishelf.Api/Mcp/Tools/GetAllBooksTool.cs
+++ b/src/Intellishelf.Api/Mcp/Tools/GetAllBooksTool.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel;
+using Intellishelf.Domain.Books.DataAccess;
+using Intellishelf.Domain.Chat.Models;
+using ModelContextProtocol;
+
+namespace Intellishelf.Api.Mcp.Tools;
+
+[McpServerToolType]
+public class GetAllBooksTool(IBookDao bookDao)
+{
+    [McpServerTool]
+    [Description("Get all books from the user's library. Returns the complete collection with title, authors, publication info, reading status, and tags.")]
+    public async Task<List<BookChatContext>> GetAllBooks(
+        [Description("The user ID whose books to retrieve")]
+        string userId)
+    {
+        var booksResult = await bookDao.GetBooksAsync(userId);
+
+        if (!booksResult.IsSuccess)
+            return [];
+
+        // Project to lightweight context (exclude heavy properties like image URLs)
+        return booksResult.Value.Select(b => new BookChatContext
+        {
+            Id = b.Id,
+            Title = b.Title,
+            Authors = b.Authors,
+            Publisher = b.Publisher,
+            PublicationDate = b.PublicationDate,
+            Pages = b.Pages,
+            Isbn10 = b.Isbn10,
+            Isbn13 = b.Isbn13,
+            Status = b.Status.ToString(),
+            StartedReadingDate = b.StartedReadingDate,
+            FinishedReadingDate = b.FinishedReadingDate,
+            Tags = b.Tags
+        }).ToList();
+    }
+}

--- a/src/Intellishelf.Api/Mcp/Tools/GetAllBooksTool.cs
+++ b/src/Intellishelf.Api/Mcp/Tools/GetAllBooksTool.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using Intellishelf.Domain.Books.DataAccess;
 using Intellishelf.Domain.Chat.Models;
-using ModelContextProtocol;
+using ModelContextProtocol.Server;
 
 namespace Intellishelf.Api.Mcp.Tools;
 

--- a/src/Intellishelf.Api/Mcp/Tools/GetBooksByAuthorTool.cs
+++ b/src/Intellishelf.Api/Mcp/Tools/GetBooksByAuthorTool.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel;
+using Intellishelf.Domain.Books.DataAccess;
+using Intellishelf.Domain.Chat.Models;
+using ModelContextProtocol;
+
+namespace Intellishelf.Api.Mcp.Tools;
+
+[McpServerToolType]
+public class GetBooksByAuthorTool(IBookDao bookDao)
+{
+    [McpServerTool]
+    [Description("Get books by a specific author from the user's library. Performs case-insensitive partial matching on author names.")]
+    public async Task<List<BookChatContext>> GetBooksByAuthor(
+        [Description("The user ID whose books to retrieve")]
+        string userId,
+        [Description("Author name to filter by (case-insensitive, partial match)")]
+        string author)
+    {
+        var booksResult = await bookDao.GetBooksAsync(userId);
+
+        if (!booksResult.IsSuccess)
+            return [];
+
+        // Filter books by author (case-insensitive partial match)
+        var filteredBooks = booksResult.Value
+            .Where(b => b.Authors != null &&
+                       b.Authors.Contains(author, StringComparison.OrdinalIgnoreCase))
+            .Select(b => new BookChatContext
+            {
+                Id = b.Id,
+                Title = b.Title,
+                Authors = b.Authors,
+                Publisher = b.Publisher,
+                PublicationDate = b.PublicationDate,
+                Pages = b.Pages,
+                Isbn10 = b.Isbn10,
+                Isbn13 = b.Isbn13,
+                Status = b.Status.ToString(),
+                StartedReadingDate = b.StartedReadingDate,
+                FinishedReadingDate = b.FinishedReadingDate,
+                Tags = b.Tags
+            })
+            .ToList();
+
+        return filteredBooks;
+    }
+}

--- a/src/Intellishelf.Api/Mcp/Tools/GetBooksByAuthorTool.cs
+++ b/src/Intellishelf.Api/Mcp/Tools/GetBooksByAuthorTool.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using Intellishelf.Domain.Books.DataAccess;
 using Intellishelf.Domain.Chat.Models;
-using ModelContextProtocol;
+using ModelContextProtocol.Server;
 
 namespace Intellishelf.Api.Mcp.Tools;
 

--- a/src/Intellishelf.Api/Modules/McpModule.cs
+++ b/src/Intellishelf.Api/Modules/McpModule.cs
@@ -1,0 +1,31 @@
+using Intellishelf.Api.Mcp.Tools;
+using Intellishelf.Api.Services;
+using Intellishelf.Domain.Chat.Services;
+using ModelContextProtocol.AspNetCore;
+
+namespace Intellishelf.Api.Modules;
+
+public static class McpModule
+{
+    public static void Register(IServiceCollection services)
+    {
+        // Register MCP tools
+        services.AddTransient<GetAllBooksTool>();
+        services.AddTransient<GetBooksByAuthorTool>();
+
+        // Register MCP tools service for ChatService integration
+        services.AddTransient<IMcpToolsService, McpToolsService>();
+
+        // Register MCP server with HTTP transport
+        services
+            .AddMcpServer()
+            .WithHttpTransport()
+            .WithToolsFromAssembly();
+    }
+
+    public static void MapMcpEndpoints(WebApplication app)
+    {
+        // Map MCP endpoints at /mcp
+        app.MapMcp("/mcp");
+    }
+}

--- a/src/Intellishelf.Api/Program.cs
+++ b/src/Intellishelf.Api/Program.cs
@@ -25,6 +25,7 @@ AzureModule.Register(builder);
 UsersModule.Register(builder);
 BooksModule.Register(builder.Services);
 AiModule.Register(builder);
+McpModule.Register(builder.Services);
 
 var app = builder.Build();
 
@@ -40,4 +41,5 @@ app.UseStatusCodePages();
 app.UseAuthorization();
 app.MapControllers();
 app.MapHealthChecks("/health");
+McpModule.MapMcpEndpoints(app);
 app.Run();

--- a/src/Intellishelf.Api/Services/McpToolsService.cs
+++ b/src/Intellishelf.Api/Services/McpToolsService.cs
@@ -1,0 +1,63 @@
+using System.Text.Json;
+using Intellishelf.Api.Mcp.Tools;
+using Intellishelf.Domain.Chat.Services;
+using OpenAI.Chat;
+
+namespace Intellishelf.Api.Services;
+
+public class McpToolsService(GetAllBooksTool getAllBooksTool, GetBooksByAuthorTool getBooksByAuthorTool)
+    : IMcpToolsService
+{
+    private static readonly ChatTool GetAllBooksToolDefinition = ChatTool.CreateFunctionTool(
+        functionName: "get_all_books",
+        functionDescription: "Get all books from the user's library. Returns the complete collection with title, authors, publication info, reading status, and tags.");
+
+    private static readonly ChatTool GetBooksByAuthorToolDefinition = ChatTool.CreateFunctionTool(
+        functionName: "get_books_by_author",
+        functionDescription: "Get books by a specific author from the user's library. Performs case-insensitive partial matching on author names.",
+        functionParameters: BinaryData.FromString("""
+            {
+                "type": "object",
+                "properties": {
+                    "author": {
+                        "type": "string",
+                        "description": "Author name to filter by (case-insensitive, partial match)"
+                    }
+                },
+                "required": ["author"],
+                "additionalProperties": false
+            }
+            """));
+
+    public IReadOnlyList<ChatTool> GetOpenAiTools()
+    {
+        return [GetAllBooksToolDefinition, GetBooksByAuthorToolDefinition];
+    }
+
+    public async Task<string> ExecuteToolAsync(string userId, string toolName, string argumentsJson)
+    {
+        return toolName switch
+        {
+            "get_all_books" => await ExecuteGetAllBooksAsync(userId),
+            "get_books_by_author" => await ExecuteGetBooksByAuthorAsync(userId, argumentsJson),
+            _ => throw new InvalidOperationException($"Unknown tool: {toolName}")
+        };
+    }
+
+    private async Task<string> ExecuteGetAllBooksAsync(string userId)
+    {
+        var books = await getAllBooksTool.GetAllBooks(userId);
+        return JsonSerializer.Serialize(books);
+    }
+
+    private async Task<string> ExecuteGetBooksByAuthorAsync(string userId, string argumentsJson)
+    {
+        var args = JsonSerializer.Deserialize<GetBooksByAuthorArgs>(argumentsJson)
+            ?? throw new InvalidOperationException("Invalid arguments for get_books_by_author");
+
+        var books = await getBooksByAuthorTool.GetBooksByAuthor(userId, args.Author);
+        return JsonSerializer.Serialize(books);
+    }
+
+    private record GetBooksByAuthorArgs(string Author);
+}

--- a/src/Intellishelf.Domain/Chat/Services/ChatService.cs
+++ b/src/Intellishelf.Domain/Chat/Services/ChatService.cs
@@ -1,47 +1,17 @@
-using System.Text.Json;
-using Intellishelf.Domain.Books.DataAccess;
-using Intellishelf.Domain.Chat.Errors;
+using System.Text;
 using Intellishelf.Domain.Chat.Models;
 using OpenAI.Chat;
 using OpenAIChatMessage = OpenAI.Chat.ChatMessage;
 
 namespace Intellishelf.Domain.Chat.Services;
 
-public class ChatService(IBookDao bookDao, ChatClient chatClient) : IChatService
+public class ChatService(IMcpToolsService mcpToolsService, ChatClient chatClient) : IChatService
 {
     public async Task<TryResult<IAsyncEnumerable<ChatStreamChunk>>> ChatStreamAsync(string userId, ChatRequest request)
     {
-        // Validate prerequisites - errors here return proper HTTP status codes
-        var booksResult = await bookDao.GetBooksAsync(userId);
-        if (!booksResult.IsSuccess)
-            return booksResult.Error;
-
-        var books = booksResult.Value;
-
-        // Project to lightweight context (exclude heavy properties)
-        var bookContexts = books.Select(b => new BookChatContext
-        {
-            Id = b.Id,
-            Title = b.Title,
-            Authors = b.Authors,
-            Publisher = b.Publisher,
-            PublicationDate = b.PublicationDate,
-            Pages = b.Pages,
-            Isbn10 = b.Isbn10,
-            Isbn13 = b.Isbn13,
-            Status = b.Status.ToString(),
-            StartedReadingDate = b.StartedReadingDate,
-            FinishedReadingDate = b.FinishedReadingDate,
-            Tags = b.Tags
-        }).ToList();
-
-        var booksJson = JsonSerializer.Serialize(bookContexts, new JsonSerializerOptions
-        {
-            WriteIndented = true
-        });
-
-        var systemPrompt = $"""
-            You are a friendly and conversational personal librarian assistant. You have access to the user's complete book collection.
+        // Build system prompt without book data (tools will provide it on demand)
+        var systemPrompt = """
+            You are a friendly and conversational personal librarian assistant. You have access to the user's book collection through tools.
 
             Your role is to:
             - Answer questions about their books naturally and conversationally
@@ -49,11 +19,7 @@ public class ChatService(IBookDao bookDao, ChatClient chatClient) : IChatService
             - Help them find specific books or information
             - Discuss their reading progress and history
 
-            Here is their book collection (in JSON format):
-
-            {booksJson}
-
-            Be helpful, conversational, and personable in your responses. When discussing books, use natural language rather than just listing data.
+            Use the available tools to access book information when needed. Be helpful, conversational, and personable in your responses.
             """;
 
         var messages = new List<OpenAIChatMessage> { OpenAIChatMessage.CreateSystemMessage(systemPrompt) };
@@ -75,23 +41,97 @@ public class ChatService(IBookDao bookDao, ChatClient chatClient) : IChatService
         messages.Add(OpenAIChatMessage.CreateUserMessage(request.Message));
 
         // Return the streaming enumerable - errors after this point are mid-stream
-        return TryResult.Success(StreamOpenAiResponseAsync(messages));
+        return TryResult.Success(StreamOpenAiResponseAsync(userId, messages));
     }
 
-    private async IAsyncEnumerable<ChatStreamChunk> StreamOpenAiResponseAsync(List<OpenAIChatMessage> messages)
+    private async IAsyncEnumerable<ChatStreamChunk> StreamOpenAiResponseAsync(string userId, List<OpenAIChatMessage> messages)
     {
-        await foreach (var update in chatClient.CompleteChatStreamingAsync(messages))
+        // Get MCP tools as OpenAI tool definitions
+        var tools = mcpToolsService.GetOpenAiTools();
+
+        var chatOptions = new ChatCompletionOptions();
+        foreach (var tool in tools)
         {
-            foreach (var contentPart in update.ContentUpdate)
-            {
-                yield return new ChatStreamChunk
-                {
-                    Content = contentPart.Text,
-                    Done = false
-                };
-            }
+            chatOptions.Tools.Add(tool);
         }
 
+        // Tool calling loop - may need multiple iterations if LLM calls tools
+        const int maxIterations = 5; // Prevent infinite loops
+        var iteration = 0;
+
+        while (iteration < maxIterations)
+        {
+            iteration++;
+
+            var toolCalls = new List<ChatToolCall>();
+            var contentBuilder = new StringBuilder();
+
+            // Stream the response and collect tool calls
+            await foreach (var update in chatClient.CompleteChatStreamingAsync(messages, chatOptions))
+            {
+                // Collect content
+                foreach (var contentPart in update.ContentUpdate)
+                {
+                    contentBuilder.Append(contentPart.Text);
+
+                    // Stream content to client
+                    yield return new ChatStreamChunk
+                    {
+                        Content = contentPart.Text,
+                        Done = false
+                    };
+                }
+
+                // Collect tool calls
+                foreach (var toolCallUpdate in update.ToolCallUpdates)
+                {
+                    toolCalls.Add(toolCallUpdate);
+                }
+
+                // Check if we're done (no tool calls)
+                if (update.FinishReason == ChatFinishReason.Stop)
+                {
+                    yield return new ChatStreamChunk
+                    {
+                        Content = string.Empty,
+                        Done = true
+                    };
+                    yield break;
+                }
+            }
+
+            // If LLM wants to call tools, execute them
+            if (toolCalls.Count > 0)
+            {
+                // Add assistant message with tool calls
+                messages.Add(OpenAIChatMessage.CreateAssistantMessage(toolCalls));
+
+                // Execute each tool call
+                foreach (var toolCall in toolCalls)
+                {
+                    var toolResult = await mcpToolsService.ExecuteToolAsync(
+                        userId,
+                        toolCall.FunctionName,
+                        toolCall.FunctionArguments.ToString());
+
+                    // Add tool result message
+                    messages.Add(OpenAIChatMessage.CreateToolMessage(toolCall.Id, toolResult));
+                }
+
+                // Continue the loop to get the final response with tool results
+                continue;
+            }
+
+            // No tool calls and no explicit stop - shouldn't happen, but break to be safe
+            yield return new ChatStreamChunk
+            {
+                Content = string.Empty,
+                Done = true
+            };
+            yield break;
+        }
+
+        // Max iterations reached
         yield return new ChatStreamChunk
         {
             Content = string.Empty,

--- a/src/Intellishelf.Domain/Chat/Services/IMcpToolsService.cs
+++ b/src/Intellishelf.Domain/Chat/Services/IMcpToolsService.cs
@@ -1,0 +1,16 @@
+using OpenAI.Chat;
+
+namespace Intellishelf.Domain.Chat.Services;
+
+public interface IMcpToolsService
+{
+    /// <summary>
+    /// Get all available MCP tools as OpenAI ChatTool definitions
+    /// </summary>
+    IReadOnlyList<ChatTool> GetOpenAiTools();
+
+    /// <summary>
+    /// Execute an MCP tool call and return the result as JSON
+    /// </summary>
+    Task<string> ExecuteToolAsync(string userId, string toolName, string argumentsJson);
+}


### PR DESCRIPTION
This commit implements a Model Context Protocol (MCP) server integrated into the Intellishelf API, replacing the previous approach of injecting all books into the chat system prompt with on-demand tool calls.

**Key Changes:**

1. **MCP Server Setup:**
   - Added ModelContextProtocol.AspNetCore NuGet package (v0.4.0-preview.3)
   - Created McpModule for dependency injection and HTTP transport configuration
   - Exposed MCP endpoints at `/api/mcp` for future external access (Claude Desktop)

2. **MCP Tools:**
   - `GetAllBooksTool`: Returns all books from user's library
   - `GetBooksByAuthorTool`: Filters books by author (case-insensitive partial match)
   - Both tools use existing BookDao for data access and return BookChatContext

3. **Chat Service Integration:**
   - Replaced direct book data injection with MCP tool-based approach
   - Created IMcpToolsService to bridge MCP tools to OpenAI tool format
   - Updated ChatService to use tool calling workflow:
     * Provides tools to OpenAI via ChatCompletionOptions
     * Handles tool calls in streaming loop * Executes tools via McpToolsService * Continues streaming with tool results

4. **Benefits:**
   - **Efficiency**: Books fetched on-demand instead of injecting entire collection
   - **Scalability**: Supports large book collections without context limit issues
   - **Extensibility**: Easy to add new tools (search by tag, status, etc.)
   - **Future-ready**: MCP HTTP server available for Claude Desktop integration

**Architecture:**
- Internal use: ChatService → McpToolsService → MCP Tools → BookDao
- External use (future): Claude Desktop → HTTP /api/mcp → MCP Tools → BookDao

**Testing:** Manual testing required to verify tool calling workflow and streaming behavior.