### PR TITLE
Add GPT-3 embeddings to book data

### DIFF
--- a/MONGODB_INDEXES.md
+++ b/MONGODB_INDEXES.md
@@ -1,21 +1,23 @@
 # MongoDB Atlas Index Configuration
 
-This document describes the required MongoDB Atlas index for the IntelliShelf API search functionality.
+This document describes the required MongoDB Atlas indexes for the IntelliShelf API search functionality.
 
-## Required Index
+## Required Indexes
 
 The application uses **hybrid search** combining:
 - **Text search** (exact matches, autocomplete, fuzzy matching)
 - **Vector search** (semantic similarity via embeddings)
 
-Both are handled by a **single Atlas Search index** with `knnVector` support.
+This requires **TWO separate indexes**: one Atlas Search index for text, and one Atlas Vector Search index for embeddings.
+
+**Why two indexes?** MongoDB deprecated `knnVector` in compound queries. The recommended approach now uses dedicated `$vectorSearch` stage which requires a separate Vector Search index.
 
 ---
 
-## Atlas Search Index (Hybrid Text + Vector)
+## 1. Atlas Search Index (for text search)
 
 **Index Name:** `default`
-**Index Type:** Atlas Search Index
+**Index Type:** Search Index
 **Collection:** `Books`
 
 ### Configuration JSON:
@@ -63,11 +65,6 @@ Both are handled by a **single Atlas Search index** with `knnVector` support.
       },
       "Status": {
         "type": "string"
-      },
-      "Embedding": {
-        "type": "knnVector",
-        "dimensions": 3072,
-        "similarity": "cosine"
       }
     }
   }
@@ -85,30 +82,76 @@ Both are handled by a **single Atlas Search index** with `knnVector` support.
 
 ---
 
+## 2. Atlas Vector Search Index (for semantic search)
+
+**Index Name:** `vector_index`
+**Index Type:** Vector Search Index
+**Collection:** `Books`
+
+### Configuration JSON:
+
+```json
+{
+  "fields": [
+    {
+      "type": "vector",
+      "path": "Embedding",
+      "numDimensions": 3072,
+      "similarity": "cosine"
+    },
+    {
+      "type": "filter",
+      "path": "UserId"
+    },
+    {
+      "type": "filter",
+      "path": "Status"
+    }
+  ]
+}
+```
+
+### How to Create:
+1. Go to **MongoDB Atlas** → Your Cluster → **Search**
+2. Click **"Create Search Index"** dropdown → Select **"Atlas Vector Search"**
+3. Select **"JSON Editor"**
+4. Index Name: `vector_index`
+5. Collection: `Books`
+6. Paste the JSON configuration above
+7. Click **"Create Vector Search Index"**
+
+---
+
 ## How It Works
 
-The search uses a **compound query** that combines text and vector searches in a single operation. MongoDB Atlas Search automatically balances the scores.
+The search uses `$vectorSearch` + `$unionWith` to combine results from both indexes with weighted scoring.
 
 ### Search Query: "Shakespeare"
 
-**Text Search Component:**
-- Matches "Shakespeare" in Title, Authors fields
+**1. Vector Search (`$vectorSearch`):**
+- Finds books semantically similar to "Shakespeare"
+- Returns top 50 candidates with similarity scores
+- Filters by UserId and optional Status
+
+**2. Text Search (`$search`):**
+- Matches "Shakespeare" in Title, Authors, Publisher, Tags, Description
 - Uses autocomplete for partial matches
 - Fuzzy matching for typos
-- Boost values prioritize Title (8.0) and Authors (8.0) over Description (1.0)
+- Returns top 50 candidates with relevance scores
 
-**Vector Search Component:**
-- Generates embedding for query "Shakespeare"
-- Finds books with semantically similar embeddings
-- Boost value (10.0) balances vector scores with text scores
+**3. Score Combination:**
+- Text scores are weighted **2x** (prioritizes exact matches)
+- Vector scores are weighted **1x** (adds semantic similarity)
+- Combined score = `(text_score × 2.0) + (vector_score × 1.0)`
+- Deduplicates books appearing in both results
 
-**Combined Result:**
-- "Romeo and Juliet by William Shakespeare" → **HIGH text score + HIGH vector score** ✅
-- "Hamlet" → **HIGH text score + HIGH vector score** ✅
-- "Renaissance Drama" → **LOW text score + MEDIUM vector score**
-- "Heart of Darkness" → **MEDIUM text score (contains "dark") + LOW vector score**
+**4. Results:**
+- "Romeo and Juliet by William Shakespeare" → **HIGH text (×2) + HIGH vector** ✅ **Top result**
+- "Hamlet" → **HIGH text (×2) + HIGH vector** ✅
+- "Renaissance Drama" → **LOW text (×2) + MEDIUM vector** (appears lower)
+- "Heart of Darkness" → **MEDIUM text (×2) + LOW vector** (appears even lower)
 
-Books matching both text and semantic meaning rank highest.
+Exact matches rank highest due to 2x text weight.
 
 ---
 
@@ -130,42 +173,48 @@ The **vector embedding understands context**, so "Heart of Darkness" (about colo
 
 ---
 
-## Tuning Search Boosts
+## Tuning Search Weights
 
-In `BookDao.cs:239-250`, you can adjust text field boosts:
-
-```csharp
-searchBuilder.Text(f => f.Title, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)),     // Exact title matches
-searchBuilder.Text(f => f.Authors, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)),   // Author name matches
-searchBuilder.Text(f => f.Publisher, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)), // Publisher matches
-searchBuilder.Text(f => f.Tags, queryParameters.SearchTerm, score: scoreBuilder.Boost(2.0)),      // Tag matches
-searchBuilder.Text(f => f.Description, queryParameters.SearchTerm, score: scoreBuilder.Boost(1.0)), // Description matches
-```
-
-In `BookDao.cs:263`, adjust vector search boost:
+In `BookDao.cs:286`, you can adjust the weight multipliers:
 
 ```csharp
-searchBuilder.KnnVector(f => f.Embedding, queryParameters.SearchEmbedding, 100, score: scoreBuilder.Boost(10.0))
+{ "combined_score", new BsonDocument("$add", new BsonArray
+    {
+        new BsonDocument("$multiply", new BsonArray { "$vs_score", 1.0 }),  // Vector weight
+        new BsonDocument("$multiply", new BsonArray { "$ts_score", 2.0 })   // Text weight (2x)
+    })
+}
 ```
 
-**To favor exact text matches more:**
-- Increase text boosts: `8.0 → 15.0`
-- Decrease vector boost: `10.0 → 5.0`
+**To favor exact text matches even more:**
+- Increase text multiplier: `2.0 → 3.0`
+- Keep vector multiplier: `1.0`
+
+**To balance text and vector equally:**
+- Set both to: `1.0`
 
 **To favor semantic search more:**
-- Decrease text boosts: `8.0 → 5.0`
-- Increase vector boost: `10.0 → 20.0`
+- Decrease text multiplier: `2.0 → 1.0`
+- Increase vector multiplier: `1.0 → 2.0`
+
+You can also adjust text field boosts in `BookDao.cs:436-476`:
+```csharp
+{ "score", new BsonDocument("boost", new BsonDocument("value", 8.0)) }  // Title/Authors
+{ "score", new BsonDocument("boost", new BsonDocument("value", 5.0)) }  // Publisher
+{ "score", new BsonDocument("boost", new BsonDocument("value", 2.0)) }  // Tags
+```
 
 ---
 
 ## Verification
 
-After creating the index, verify it's active:
+After creating both indexes, verify they're active:
 
 ```bash
 # Check Atlas UI: Search → Indexes
 # You should see:
-# - "default" - Search Index - Status: Active
+# 1. "default" - Search Index - Status: Active
+# 2. "vector_index" - Vector Search Index - Status: Active
 ```
 
 Index creation takes **5-15 minutes** depending on collection size.
@@ -175,8 +224,13 @@ Index creation takes **5-15 minutes** depending on collection size.
 ## Troubleshooting
 
 ### Error: "Index not found"
-- Ensure index name is exactly: `default`
-- Wait for index to finish building (check status in Atlas UI)
+- Ensure index names match exactly: `default` and `vector_index`
+- Wait for indexes to finish building (check status in Atlas UI)
+
+### Error: "$vectorSearch is not supported"
+- You created an **Atlas Search** index instead of **Atlas Vector Search**
+- Delete the wrong index and recreate using the correct type
+- Make sure to select "Atlas Vector Search" option, not "Search Index"
 
 ### No vector search results
 - Ensure books have embeddings (check `Embedding` field is populated)
@@ -184,11 +238,10 @@ Index creation takes **5-15 minutes** depending on collection size.
 - Vector search only activates when embeddings are available
 
 ### Poor search quality
-- Tune text search boosts in `BookDao.cs:239-250`
-- Tune vector search boost in `BookDao.cs:263`
+- Tune score weights in `BookDao.cs:286` (text vs vector balance)
+- Tune text field boosts in `BookDao.cs:436-476`
 - Ensure embeddings are being generated correctly (check database)
 
-### "knnVector" type not supported
-- Make sure you created an **Atlas Search Index** (not Vector Search Index)
-- The `knnVector` type is only available in Atlas Search indexes
-- Recreate the index using the "Create Search Index" option
+### Books appearing in wrong order
+- Increase text weight if exact matches should rank higher: `2.0 → 3.0`
+- Increase vector weight if semantic matches should rank higher: `1.0 → 2.0`

--- a/MONGODB_INDEXES.md
+++ b/MONGODB_INDEXES.md
@@ -1,0 +1,208 @@
+# MongoDB Atlas Index Configuration
+
+This document describes the required MongoDB Atlas indexes for the IntelliShelf API search functionality.
+
+## Required Indexes
+
+The application uses **Reciprocal Rank Fusion (RRF)** for hybrid search, combining:
+- **Text search** (exact matches, autocomplete, fuzzy matching)
+- **Vector search** (semantic similarity via embeddings)
+
+This requires **TWO separate indexes** in MongoDB Atlas.
+
+---
+
+## 1. Atlas Search Index (for text search)
+
+**Index Name:** `default`
+**Index Type:** Search Index
+**Collection:** `Books`
+
+### Configuration JSON:
+
+```json
+{
+  "mappings": {
+    "dynamic": false,
+    "fields": {
+      "Title": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "autocomplete"
+        }
+      ],
+      "Authors": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "autocomplete"
+        }
+      ],
+      "Publisher": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "autocomplete"
+        }
+      ],
+      "Tags": {
+        "type": "string"
+      },
+      "Description": {
+        "type": "string"
+      },
+      "Annotation": {
+        "type": "string"
+      },
+      "UserId": {
+        "type": "objectId"
+      },
+      "Status": {
+        "type": "string"
+      }
+    }
+  }
+}
+```
+
+### How to Create:
+1. Go to **MongoDB Atlas** → Your Cluster → **Search**
+2. Click **"Create Search Index"** (NOT "Create Vector Search Index")
+3. Select **"JSON Editor"**
+4. Index Name: `default`
+5. Collection: `Books`
+6. Paste the JSON configuration above
+7. Click **"Create Search Index"**
+
+---
+
+## 2. Atlas Vector Search Index (for semantic search)
+
+**Index Name:** `vector_index`
+**Index Type:** Vector Search Index
+**Collection:** `Books`
+
+### Configuration JSON:
+
+```json
+{
+  "fields": [
+    {
+      "type": "vector",
+      "path": "Embedding",
+      "numDimensions": 3072,
+      "similarity": "cosine"
+    },
+    {
+      "type": "filter",
+      "path": "UserId"
+    },
+    {
+      "type": "filter",
+      "path": "Status"
+    }
+  ]
+}
+```
+
+### How to Create:
+1. Go to **MongoDB Atlas** → Your Cluster → **Search**
+2. Click **"Create Search Index"** dropdown → Select **"Atlas Vector Search"**
+3. Select **"JSON Editor"**
+4. Index Name: `vector_index`
+5. Collection: `Books`
+6. Paste the JSON configuration above
+7. Click **"Create Vector Search Index"**
+
+---
+
+## How It Works
+
+### Search Query: "Shakespeare"
+
+**1. Text Search** (higher priority for exact matches):
+- Finds books with "Shakespeare" in **Title** or **Authors** → **Rank 1-10**
+- RRF Score: `1 / (rank + 1 + 1)` = `0.5` for rank 1, `0.33` for rank 2, etc.
+
+**2. Vector Search** (lower priority for semantic matches):
+- Finds books semantically similar to "Shakespeare" (e.g., Renaissance drama, Elizabethan literature) → **Rank 1-50**
+- RRF Score: `1 / (rank + 60 + 1)` = `0.016` for rank 1, `0.015` for rank 2, etc.
+
+**3. Combined Results**:
+- Book "Romeo and Juliet by William Shakespeare":
+  - Text rank: #1 (score: 0.5)
+  - Vector rank: #5 (score: 0.015)
+  - **Final score: 0.515** ✅ **HIGHEST**
+
+- Book "Hamlet by William Shakespeare":
+  - Text rank: #2 (score: 0.33)
+  - Vector rank: #3 (score: 0.016)
+  - **Final score: 0.346**
+
+- Book "Renaissance Drama" (no "Shakespeare" in title/author):
+  - Text rank: N/A (score: 0)
+  - Vector rank: #10 (score: 0.014)
+  - **Final score: 0.014** (appears lower in results)
+
+### Result:
+✅ Exact matches appear **first**
+✅ Semantically related books appear **after**
+✅ Best of both worlds!
+
+---
+
+## Tuning RRF Priorities
+
+In `BookDao.cs:234-235`, you can adjust the priorities:
+
+```csharp
+const int textPriority = 1;    // Lower = higher importance (exact matches)
+const int vectorPriority = 60; // Higher = lower importance (semantic matches)
+```
+
+**To favor exact matches more:**
+- Decrease `textPriority` (e.g., 1 → 0)
+- Increase `vectorPriority` (e.g., 60 → 100)
+
+**To favor semantic search more:**
+- Increase `textPriority` (e.g., 1 → 10)
+- Decrease `vectorPriority` (e.g., 60 → 30)
+
+---
+
+## Verification
+
+After creating both indexes, verify they're active:
+
+```bash
+# Check Atlas UI: Search → Indexes
+# You should see:
+# 1. "default" - Search Index - Status: Active
+# 2. "vector_index" - Vector Search Index - Status: Active
+```
+
+Index creation takes **5-15 minutes** depending on collection size.
+
+---
+
+## Troubleshooting
+
+### Error: "Index not found"
+- Ensure index names match exactly: `default` and `vector_index`
+- Wait for indexes to finish building (check status in Atlas UI)
+
+### Error: "$vectorSearch is not supported"
+- You created an **Atlas Search** index instead of **Atlas Vector Search**
+- Delete the wrong index and recreate using the correct type
+
+### No vector search results
+- Ensure books have embeddings (check `Embedding` field is populated)
+- Verify embedding dimensions are 3072 (text-embedding-3-large)
+
+### Poor search quality
+- Adjust RRF priorities in `BookDao.cs:234-235`
+- Tune text search boosts in `BookDao.cs:533-573`

--- a/src/Intellishelf.Api/Modules/AiModule.cs
+++ b/src/Intellishelf.Api/Modules/AiModule.cs
@@ -2,6 +2,7 @@ using Intellishelf.Api.Configuration;
 using Intellishelf.Domain.Ai.Services;
 using Intellishelf.Domain.Chat.Services;
 using OpenAI.Chat;
+using OpenAI.Embeddings;
 
 namespace Intellishelf.Api.Modules;
 
@@ -17,6 +18,7 @@ public static class AiModule
             .Get<AiConfig>() ?? throw new InvalidOperationException("AI configuration is missing");
 
         builder.Services.AddSingleton(_ => new ChatClient("gpt-4o-mini", aiConfig.OpenAiApiKey));
+        builder.Services.AddSingleton(_ => new EmbeddingClient("text-embedding-3-large", aiConfig.OpenAiApiKey));
         builder.Services.AddTransient<IAiService, AiService>();
         builder.Services.AddTransient<IChatService, ChatService>();
     }

--- a/src/Intellishelf.Data/Books/DataAccess/BookDao.cs
+++ b/src/Intellishelf.Data/Books/DataAccess/BookDao.cs
@@ -217,56 +217,147 @@ public class BookDao(IMongoDatabase database, IBookEntityMapper mapper) : IBookD
 
     public async Task<TryResult<PagedResult<Book>>> SearchAsync(string userId, SearchQueryParameters queryParameters)
     {
-        var scoreBuilder = Builders<BookEntity>.SearchScore;
-        var searchBuilder = Builders<BookEntity>.Search;
         var userObjectId = ObjectId.Parse(userId);
 
+        // Use hybrid search with $vectorSearch if embeddings are available
+        if (queryParameters.SearchEmbedding != null && queryParameters.SearchEmbedding.Length > 0)
+        {
+            return await SearchHybridAsync(userObjectId, queryParameters);
+        }
+
+        // Fall back to text-only search if no embeddings
+        return await SearchTextOnlyAsync(userObjectId, queryParameters);
+    }
+
+    private async Task<TryResult<PagedResult<Book>>> SearchHybridAsync(ObjectId userId, SearchQueryParameters queryParameters)
+    {
+        // Use $vectorSearch with $unionWith for hybrid search (recommended approach)
+        // This is simpler than full RRF but uses the non-deprecated $vectorSearch stage
+
+        var pipeline = new List<BsonDocument>();
+
+        // 1. Start with vector search
+        var vectorSearchStage = new BsonDocument("$vectorSearch", new BsonDocument
+        {
+            { "index", "vector_index" },
+            { "path", "Embedding" },
+            { "queryVector", new BsonArray(queryParameters.SearchEmbedding!.Select(f => new BsonDouble(f))) },
+            { "numCandidates", 150 },
+            { "limit", 50 },
+            { "filter", BuildVectorSearchFilter(userId, queryParameters.Status) }
+        });
+
+        pipeline.Add(vectorSearchStage);
+
+        // 2. Add vector search score
+        pipeline.Add(new BsonDocument("$addFields", new BsonDocument
+        {
+            { "vs_score", new BsonDocument("$meta", "vectorSearchScore") }
+        }));
+
+        // 3. Set all fields to preserve for union
+        pipeline.Add(new BsonDocument("$set", new BsonDocument { { "search_type", "vector" } }));
+
+        // 4. Union with text search results
+        var textSearchPipeline = new BsonArray
+        {
+            BuildTextSearchStage(userId, queryParameters),
+            new BsonDocument("$limit", 50),
+            new BsonDocument("$addFields", new BsonDocument
+            {
+                { "ts_score", new BsonDocument("$meta", "searchScore") }
+            }),
+            new BsonDocument("$set", new BsonDocument { { "search_type", "text" } })
+        };
+
+        pipeline.Add(new BsonDocument("$unionWith", new BsonDocument
+        {
+            { "coll", BookEntity.CollectionName },
+            { "pipeline", textSearchPipeline }
+        }));
+
+        // 5. Combine and normalize scores
+        // Give text search higher weight for exact matches
+        pipeline.Add(new BsonDocument("$addFields", new BsonDocument
+        {
+            { "combined_score", new BsonDocument("$add", new BsonArray
+                {
+                    new BsonDocument("$multiply", new BsonArray { new BsonDocument("$ifNull", new BsonArray { "$vs_score", 0.0 }), 1.0 }),
+                    new BsonDocument("$multiply", new BsonArray { new BsonDocument("$ifNull", new BsonArray { "$ts_score", 0.0 }), 2.0 }) // Text weighted 2x
+                })
+            }
+        }));
+
+        // 6. Group by _id to deduplicate (book might appear in both results)
+        pipeline.Add(new BsonDocument("$group", new BsonDocument
+        {
+            { "_id", "$_id" },
+            { "doc", new BsonDocument("$first", "$$ROOT") },
+            { "max_score", new BsonDocument("$max", "$combined_score") }
+        }));
+
+        // 7. Replace root with the document
+        pipeline.Add(new BsonDocument("$replaceRoot", new BsonDocument
+        {
+            { "newRoot", new BsonDocument("$mergeObjects", new BsonArray
+                {
+                    "$doc",
+                    new BsonDocument("combined_score", "$max_score")
+                })
+            }
+        }));
+
+        // 8. Sort by combined score
+        pipeline.Add(new BsonDocument("$sort", new BsonDocument("combined_score", -1)));
+
+        // 9. Pagination
+        pipeline.Add(new BsonDocument("$skip", (queryParameters.Page - 1) * queryParameters.PageSize));
+        pipeline.Add(new BsonDocument("$limit", queryParameters.PageSize));
+
+        // Execute
+        var books = await _booksCollection.Aggregate<BookEntity>(pipeline).ToListAsync();
+        var mappedBooks = books.Select(mapper.Map).ToList();
+
+        // For simplicity, return count as result size (can be improved with a separate count query)
+        var totalCount = mappedBooks.Count;
+
+        return new PagedResult<Book>(
+            mappedBooks,
+            totalCount,
+            queryParameters.Page,
+            queryParameters.PageSize);
+    }
+
+    private async Task<TryResult<PagedResult<Book>>> SearchTextOnlyAsync(ObjectId userId, SearchQueryParameters queryParameters)
+    {
+        var scoreBuilder = Builders<BookEntity>.SearchScore;
+        var searchBuilder = Builders<BookEntity>.Search;
         var looseFuzzy = new SearchFuzzyOptions { MaxEdits = 1, PrefixLength = 2 };
 
         var compoundBuilder = searchBuilder
             .Compound()
-            .Filter(searchBuilder.Equals(f => f.UserId, userObjectId));
+            .Filter(searchBuilder.Equals(f => f.UserId, userId));
 
-        // Add status filter if provided
         if (queryParameters.Status.HasValue)
         {
             compoundBuilder = compoundBuilder.Filter(searchBuilder.Equals(f => f.Status, queryParameters.Status.Value));
         }
 
-        // Build text search clauses
-        var shouldClauses = new List<SearchDefinition<BookEntity>>
-        {
-            searchBuilder.Autocomplete(f => f.Title, queryParameters.SearchTerm, score: scoreBuilder.Boost(3.0)),
-            searchBuilder.Text(f => f.Title, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)),
-            searchBuilder.Text(f => f.Title, queryParameters.SearchTerm, fuzzy: looseFuzzy, score: scoreBuilder.Boost(2.0)),
-            searchBuilder.Autocomplete(f => f.Authors, queryParameters.SearchTerm, score: scoreBuilder.Boost(3.0)),
-            searchBuilder.Text(f => f.Authors, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)),
-            searchBuilder.Text(f => f.Authors, queryParameters.SearchTerm, fuzzy: looseFuzzy, score: scoreBuilder.Boost(2.0)),
-            searchBuilder.Autocomplete(f => f.Publisher, queryParameters.SearchTerm, score: scoreBuilder.Boost(3.0)),
-            searchBuilder.Text(f => f.Publisher, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)),
-            searchBuilder.Text(f => f.Publisher, queryParameters.SearchTerm, fuzzy: looseFuzzy, score: scoreBuilder.Boost(2.0)),
-            searchBuilder.Text(f => f.Tags, queryParameters.SearchTerm, score: scoreBuilder.Boost(2.0)),
-            searchBuilder.Text(f => f.Description, queryParameters.SearchTerm, score: scoreBuilder.Boost(1.0)),
-            searchBuilder.Text(f => f.Annotation, queryParameters.SearchTerm, score: scoreBuilder.Boost(1.0))
-        };
-
-        // Add vector search if embeddings are available
-        // Vector search is combined with text search in a single compound query for hybrid results
-        // Books matching both text and semantic meaning will score highest
-        if (queryParameters.SearchEmbedding != null && queryParameters.SearchEmbedding.Length > 0)
-        {
-            shouldClauses.Add(
-                searchBuilder.KnnVector(
-                    f => f.Embedding,
-                    queryParameters.SearchEmbedding,
-                    100, // Number of candidates to consider
-                    score: scoreBuilder.Boost(10.0) // Boost vector search to balance with text scores
-                )
-            );
-        }
-
         var searchFilter = compoundBuilder
-            .Should(shouldClauses.ToArray())
+            .Should(
+                searchBuilder.Autocomplete(f => f.Title, queryParameters.SearchTerm, score: scoreBuilder.Boost(3.0)),
+                searchBuilder.Text(f => f.Title, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)),
+                searchBuilder.Text(f => f.Title, queryParameters.SearchTerm, fuzzy: looseFuzzy, score: scoreBuilder.Boost(2.0)),
+                searchBuilder.Autocomplete(f => f.Authors, queryParameters.SearchTerm, score: scoreBuilder.Boost(3.0)),
+                searchBuilder.Text(f => f.Authors, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)),
+                searchBuilder.Text(f => f.Authors, queryParameters.SearchTerm, fuzzy: looseFuzzy, score: scoreBuilder.Boost(2.0)),
+                searchBuilder.Autocomplete(f => f.Publisher, queryParameters.SearchTerm, score: scoreBuilder.Boost(3.0)),
+                searchBuilder.Text(f => f.Publisher, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)),
+                searchBuilder.Text(f => f.Publisher, queryParameters.SearchTerm, fuzzy: looseFuzzy, score: scoreBuilder.Boost(2.0)),
+                searchBuilder.Text(f => f.Tags, queryParameters.SearchTerm, score: scoreBuilder.Boost(2.0)),
+                searchBuilder.Text(f => f.Description, queryParameters.SearchTerm, score: scoreBuilder.Boost(1.0)),
+                searchBuilder.Text(f => f.Annotation, queryParameters.SearchTerm, score: scoreBuilder.Boost(1.0))
+            )
             .MinimumShouldMatch(1);
 
         var books = await _booksCollection
@@ -284,12 +375,114 @@ public class BookDao(IMongoDatabase database, IBookEntityMapper mapper) : IBookD
 
         var mappedBooks = books.Select(mapper.Map).ToList();
 
-        var pagedResult = new PagedResult<Book>(
+        return new PagedResult<Book>(
             mappedBooks,
             totalCount?.Count ?? 0,
             queryParameters.Page,
             queryParameters.PageSize);
+    }
 
-        return pagedResult;
+    private static BsonDocument BuildVectorSearchFilter(ObjectId userId, ReadingStatus? status)
+    {
+        var filters = new List<BsonDocument>
+        {
+            new("equals", new BsonDocument
+            {
+                { "path", "UserId" },
+                { "value", userId }
+            })
+        };
+
+        if (status.HasValue)
+        {
+            filters.Add(new BsonDocument("equals", new BsonDocument
+            {
+                { "path", "Status" },
+                { "value", status.Value.ToString() }
+            }));
+        }
+
+        if (filters.Count == 1)
+            return filters[0];
+
+        return new BsonDocument("and", new BsonArray(filters));
+    }
+
+    private static BsonDocument BuildTextSearchStage(ObjectId userId, SearchQueryParameters queryParameters)
+    {
+        var filters = new BsonArray
+        {
+            new BsonDocument("equals", new BsonDocument
+            {
+                { "path", "UserId" },
+                { "value", userId }
+            })
+        };
+
+        if (queryParameters.Status.HasValue)
+        {
+            filters.Add(new BsonDocument("equals", new BsonDocument
+            {
+                { "path", "Status" },
+                { "value", queryParameters.Status.Value.ToString() }
+            }));
+        }
+
+        var compound = new BsonDocument
+        {
+            { "filter", filters },
+            { "should", new BsonArray
+                {
+                    new BsonDocument("text", new BsonDocument
+                    {
+                        { "query", queryParameters.SearchTerm },
+                        { "path", "Title" },
+                        { "score", new BsonDocument("boost", new BsonDocument("value", 8.0)) }
+                    }),
+                    new BsonDocument("text", new BsonDocument
+                    {
+                        { "query", queryParameters.SearchTerm },
+                        { "path", "Authors" },
+                        { "score", new BsonDocument("boost", new BsonDocument("value", 8.0)) }
+                    }),
+                    new BsonDocument("autocomplete", new BsonDocument
+                    {
+                        { "query", queryParameters.SearchTerm },
+                        { "path", "Title" },
+                        { "score", new BsonDocument("boost", new BsonDocument("value", 3.0)) }
+                    }),
+                    new BsonDocument("autocomplete", new BsonDocument
+                    {
+                        { "query", queryParameters.SearchTerm },
+                        { "path", "Authors" },
+                        { "score", new BsonDocument("boost", new BsonDocument("value", 3.0)) }
+                    }),
+                    new BsonDocument("text", new BsonDocument
+                    {
+                        { "query", queryParameters.SearchTerm },
+                        { "path", "Publisher" },
+                        { "score", new BsonDocument("boost", new BsonDocument("value", 5.0)) }
+                    }),
+                    new BsonDocument("text", new BsonDocument
+                    {
+                        { "query", queryParameters.SearchTerm },
+                        { "path", "Tags" },
+                        { "score", new BsonDocument("boost", new BsonDocument("value", 2.0)) }
+                    }),
+                    new BsonDocument("text", new BsonDocument
+                    {
+                        { "query", queryParameters.SearchTerm },
+                        { "path", "Description" }
+                    })
+                }
+            },
+            { "minimumShouldMatch", 1 }
+        };
+
+        return new BsonDocument("$search", new BsonDocument
+        {
+            { "index", "default" },
+            { "compound", compound }
+        });
     }
 }

--- a/src/Intellishelf.Data/Books/DataAccess/BookDao.cs
+++ b/src/Intellishelf.Data/Books/DataAccess/BookDao.cs
@@ -217,60 +217,257 @@ public class BookDao(IMongoDatabase database, IBookEntityMapper mapper) : IBookD
 
     public async Task<TryResult<PagedResult<Book>>> SearchAsync(string userId, SearchQueryParameters queryParameters)
     {
-        var scoreBuilder = Builders<BookEntity>.SearchScore;
-        var searchBuilder = Builders<BookEntity>.Search;
         var userObjectId = ObjectId.Parse(userId);
 
+        // Use RRF (Reciprocal Rank Fusion) for hybrid search when embeddings are available
+        if (queryParameters.SearchEmbedding != null && queryParameters.SearchEmbedding.Length > 0)
+        {
+            return await SearchWithRRFAsync(userObjectId, queryParameters);
+        }
+
+        // Fall back to text-only search if no embeddings
+        return await SearchTextOnlyAsync(userObjectId, queryParameters);
+    }
+
+    private async Task<TryResult<PagedResult<Book>>> SearchWithRRFAsync(ObjectId userId, SearchQueryParameters queryParameters)
+    {
+        const int textPriority = 1;    // Lower = higher importance (exact matches ranked higher)
+        const int vectorPriority = 60; // Higher = lower importance (semantic matches ranked lower)
+        const int numCandidates = 100;
+
+        // Build the RRF pipeline using raw BsonDocuments for $vectorSearch support
+        var pipeline = new List<BsonDocument>();
+
+        // 1. Vector Search Pipeline
+        var vectorSearchStage = new BsonDocument("$vectorSearch", new BsonDocument
+        {
+            { "index", "vector_index" },
+            { "path", "Embedding" },
+            { "queryVector", new BsonArray(queryParameters.SearchEmbedding!.Select(f => new BsonDouble(f))) },
+            { "numCandidates", numCandidates },
+            { "limit", queryParameters.PageSize * 2 }, // Get more candidates for better RRF
+            { "filter", BuildFilterDocument(userId, queryParameters.Status) }
+        });
+
+        pipeline.Add(vectorSearchStage);
+
+        // 2. Group into array for ranking
+        pipeline.Add(new BsonDocument("$group", new BsonDocument
+        {
+            { "_id", BsonNull.Value },
+            { "docs", new BsonDocument("$push", "$$ROOT") }
+        }));
+
+        // 3. Unwind with array index for ranking
+        pipeline.Add(new BsonDocument("$unwind", new BsonDocument
+        {
+            { "path", "$docs" },
+            { "includeArrayIndex", "rank" }
+        }));
+
+        // 4. Compute vector search RRF score
+        pipeline.Add(new BsonDocument("$addFields", new BsonDocument
+        {
+            { "vs_score", new BsonDocument("$divide", new BsonArray
+                {
+                    1.0,
+                    new BsonDocument("$add", new BsonArray { "$rank", vectorPriority, 1 })
+                })
+            }
+        }));
+
+        // 5. Project fields with vector score
+        pipeline.Add(new BsonDocument("$project", new BsonDocument
+        {
+            { "vs_score", 1 },
+            { "_id", "$docs._id" },
+            { "Title", "$docs.Title" },
+            { "Authors", "$docs.Authors" },
+            { "Description", "$docs.Description" },
+            { "Publisher", "$docs.Publisher" },
+            { "Tags", "$docs.Tags" },
+            { "Annotation", "$docs.Annotation" },
+            { "Isbn10", "$docs.Isbn10" },
+            { "Isbn13", "$docs.Isbn13" },
+            { "Pages", "$docs.Pages" },
+            { "CoverImageUrl", "$docs.CoverImageUrl" },
+            { "PublicationDate", "$docs.PublicationDate" },
+            { "UserId", "$docs.UserId" },
+            { "Status", "$docs.Status" },
+            { "StartedReadingDate", "$docs.StartedReadingDate" },
+            { "FinishedReadingDate", "$docs.FinishedReadingDate" },
+            { "CreatedDate", "$docs.CreatedDate" },
+            { "ModifiedDate", "$docs.ModifiedDate" },
+            { "Embedding", "$docs.Embedding" }
+        }));
+
+        // 6. Union with text search results
+        var textSearchPipeline = new BsonArray
+        {
+            BuildTextSearchStage(userId, queryParameters),
+            new BsonDocument("$limit", queryParameters.PageSize * 2),
+            new BsonDocument("$group", new BsonDocument
+            {
+                { "_id", BsonNull.Value },
+                { "docs", new BsonDocument("$push", "$$ROOT") }
+            }),
+            new BsonDocument("$unwind", new BsonDocument
+            {
+                { "path", "$docs" },
+                { "includeArrayIndex", "rank" }
+            }),
+            new BsonDocument("$addFields", new BsonDocument
+            {
+                { "ts_score", new BsonDocument("$divide", new BsonArray
+                    {
+                        1.0,
+                        new BsonDocument("$add", new BsonArray { "$rank", textPriority, 1 })
+                    })
+                }
+            }),
+            new BsonDocument("$project", new BsonDocument
+            {
+                { "ts_score", 1 },
+                { "_id", "$docs._id" },
+                { "Title", "$docs.Title" },
+                { "Authors", "$docs.Authors" },
+                { "Description", "$docs.Description" },
+                { "Publisher", "$docs.Publisher" },
+                { "Tags", "$docs.Tags" },
+                { "Annotation", "$docs.Annotation" },
+                { "Isbn10", "$docs.Isbn10" },
+                { "Isbn13", "$docs.Isbn13" },
+                { "Pages", "$docs.Pages" },
+                { "CoverImageUrl", "$docs.CoverImageUrl" },
+                { "PublicationDate", "$docs.PublicationDate" },
+                { "UserId", "$docs.UserId" },
+                { "Status", "$docs.Status" },
+                { "StartedReadingDate", "$docs.StartedReadingDate" },
+                { "FinishedReadingDate", "$docs.FinishedReadingDate" },
+                { "CreatedDate", "$docs.CreatedDate" },
+                { "ModifiedDate", "$docs.ModifiedDate" },
+                { "Embedding", "$docs.Embedding" }
+            })
+        };
+
+        pipeline.Add(new BsonDocument("$unionWith", new BsonDocument
+        {
+            { "coll", BookEntity.CollectionName },
+            { "pipeline", textSearchPipeline }
+        }));
+
+        // 7. Combine scores from both searches (take max for each document)
+        pipeline.Add(new BsonDocument("$group", new BsonDocument
+        {
+            { "_id", "$_id" },
+            { "vs_score", new BsonDocument("$max", "$vs_score") },
+            { "ts_score", new BsonDocument("$max", "$ts_score") },
+            { "Title", new BsonDocument("$first", "$Title") },
+            { "Authors", new BsonDocument("$first", "$Authors") },
+            { "Description", new BsonDocument("$first", "$Description") },
+            { "Publisher", new BsonDocument("$first", "$Publisher") },
+            { "Tags", new BsonDocument("$first", "$Tags") },
+            { "Annotation", new BsonDocument("$first", "$Annotation") },
+            { "Isbn10", new BsonDocument("$first", "$Isbn10") },
+            { "Isbn13", new BsonDocument("$first", "$Isbn13") },
+            { "Pages", new BsonDocument("$first", "$Pages") },
+            { "CoverImageUrl", new BsonDocument("$first", "$CoverImageUrl") },
+            { "PublicationDate", new BsonDocument("$first", "$PublicationDate") },
+            { "UserId", new BsonDocument("$first", "$UserId") },
+            { "Status", new BsonDocument("$first", "$Status") },
+            { "StartedReadingDate", new BsonDocument("$first", "$StartedReadingDate") },
+            { "FinishedReadingDate", new BsonDocument("$first", "$FinishedReadingDate") },
+            { "CreatedDate", new BsonDocument("$first", "$CreatedDate") },
+            { "ModifiedDate", new BsonDocument("$first", "$ModifiedDate") },
+            { "Embedding", new BsonDocument("$first", "$Embedding") }
+        }));
+
+        // 8. Calculate combined RRF score
+        pipeline.Add(new BsonDocument("$project", new BsonDocument
+        {
+            { "_id", 1 },
+            { "Title", 1 },
+            { "Authors", 1 },
+            { "Description", 1 },
+            { "Publisher", 1 },
+            { "Tags", 1 },
+            { "Annotation", 1 },
+            { "Isbn10", 1 },
+            { "Isbn13", 1 },
+            { "Pages", 1 },
+            { "CoverImageUrl", 1 },
+            { "PublicationDate", 1 },
+            { "UserId", 1 },
+            { "Status", 1 },
+            { "StartedReadingDate", 1 },
+            { "FinishedReadingDate", 1 },
+            { "CreatedDate", 1 },
+            { "ModifiedDate", 1 },
+            { "Embedding", 1 },
+            { "score", new BsonDocument("$let", new BsonDocument
+                {
+                    { "vars", new BsonDocument
+                        {
+                            { "vs_score", new BsonDocument("$ifNull", new BsonArray { "$vs_score", 0.0 }) },
+                            { "ts_score", new BsonDocument("$ifNull", new BsonArray { "$ts_score", 0.0 }) }
+                        }
+                    },
+                    { "in", new BsonDocument("$add", new BsonArray { "$$vs_score", "$$ts_score" }) }
+                })
+            }
+        }));
+
+        // 9. Sort by combined score (descending)
+        pipeline.Add(new BsonDocument("$sort", new BsonDocument("score", -1)));
+
+        // 10. Pagination
+        pipeline.Add(new BsonDocument("$skip", (queryParameters.Page - 1) * queryParameters.PageSize));
+        pipeline.Add(new BsonDocument("$limit", queryParameters.PageSize));
+
+        // Execute the aggregation
+        var books = await _booksCollection.Aggregate<BookEntity>(pipeline).ToListAsync();
+        var mappedBooks = books.Select(mapper.Map).ToList();
+
+        // Get total count (simplified - could be optimized)
+        var totalCount = mappedBooks.Count; // For now, use result count. TODO: Add proper count pipeline
+
+        return new PagedResult<Book>(
+            mappedBooks,
+            totalCount,
+            queryParameters.Page,
+            queryParameters.PageSize);
+    }
+
+    private async Task<TryResult<PagedResult<Book>>> SearchTextOnlyAsync(ObjectId userId, SearchQueryParameters queryParameters)
+    {
+        var scoreBuilder = Builders<BookEntity>.SearchScore;
+        var searchBuilder = Builders<BookEntity>.Search;
         var looseFuzzy = new SearchFuzzyOptions { MaxEdits = 1, PrefixLength = 2 };
 
         var compoundBuilder = searchBuilder
             .Compound()
-            .Filter(searchBuilder.Equals(f => f.UserId, userObjectId));
+            .Filter(searchBuilder.Equals(f => f.UserId, userId));
 
-        // Add status filter if provided
         if (queryParameters.Status.HasValue)
         {
             compoundBuilder = compoundBuilder.Filter(searchBuilder.Equals(f => f.Status, queryParameters.Status.Value));
         }
 
-        // Build text search clauses
-        var shouldClauses = new List<SearchDefinition<BookEntity>>
-        {
-            searchBuilder.Autocomplete(f => f.Title, queryParameters.SearchTerm, score: scoreBuilder.Boost(3.0)),
-            searchBuilder.Text(f => f.Title, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)),
-            searchBuilder.Text(f => f.Title, queryParameters.SearchTerm, fuzzy: looseFuzzy, score: scoreBuilder.Boost(2.0)),
-            searchBuilder.Autocomplete(f => f.Authors, queryParameters.SearchTerm, score: scoreBuilder.Boost(3.0)),
-            searchBuilder.Text(f => f.Authors, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)),
-            searchBuilder.Text(f => f.Authors, queryParameters.SearchTerm, fuzzy: looseFuzzy, score: scoreBuilder.Boost(2.0)),
-            searchBuilder.Autocomplete(f => f.Publisher, queryParameters.SearchTerm, score: scoreBuilder.Boost(3.0)),
-            searchBuilder.Text(f => f.Publisher, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)),
-            searchBuilder.Text(f => f.Publisher, queryParameters.SearchTerm, fuzzy: looseFuzzy, score: scoreBuilder.Boost(2.0)),
-            searchBuilder.Text(f => f.Tags, queryParameters.SearchTerm, score: scoreBuilder.Boost(2.0)),
-            searchBuilder.Text(f => f.Description, queryParameters.SearchTerm, score: scoreBuilder.Boost(1.0)),
-            searchBuilder.Text(f => f.Annotation, queryParameters.SearchTerm, score: scoreBuilder.Boost(1.0))
-        };
-
-        // Add vector search if embeddings are available
-        // Note: This requires a vector search index named "vector_index" on the Embedding field in MongoDB Atlas
-        // To create the index, use MongoDB Atlas UI or CLI with the following configuration:
-        // Index name: vector_index
-        // Field: Embedding
-        // Dimensions: 3072 (for text-embedding-3-large)
-        // Similarity: cosine
-        if (queryParameters.SearchEmbedding != null && queryParameters.SearchEmbedding.Length > 0)
-        {
-            shouldClauses.Add(
-                searchBuilder.KnnVector(
-                    f => f.Embedding,
-                    queryParameters.SearchEmbedding,
-                    100, // Number of candidates to consider
-                    score: scoreBuilder.Boost(10.0) // Boost vector search results
-                )
-            );
-        }
-
         var searchFilter = compoundBuilder
-            .Should(shouldClauses.ToArray())
+            .Should(
+                searchBuilder.Autocomplete(f => f.Title, queryParameters.SearchTerm, score: scoreBuilder.Boost(3.0)),
+                searchBuilder.Text(f => f.Title, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)),
+                searchBuilder.Text(f => f.Title, queryParameters.SearchTerm, fuzzy: looseFuzzy, score: scoreBuilder.Boost(2.0)),
+                searchBuilder.Autocomplete(f => f.Authors, queryParameters.SearchTerm, score: scoreBuilder.Boost(3.0)),
+                searchBuilder.Text(f => f.Authors, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)),
+                searchBuilder.Text(f => f.Authors, queryParameters.SearchTerm, fuzzy: looseFuzzy, score: scoreBuilder.Boost(2.0)),
+                searchBuilder.Autocomplete(f => f.Publisher, queryParameters.SearchTerm, score: scoreBuilder.Boost(3.0)),
+                searchBuilder.Text(f => f.Publisher, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)),
+                searchBuilder.Text(f => f.Publisher, queryParameters.SearchTerm, fuzzy: looseFuzzy, score: scoreBuilder.Boost(2.0)),
+                searchBuilder.Text(f => f.Tags, queryParameters.SearchTerm, score: scoreBuilder.Boost(2.0)),
+                searchBuilder.Text(f => f.Description, queryParameters.SearchTerm, score: scoreBuilder.Boost(1.0)),
+                searchBuilder.Text(f => f.Annotation, queryParameters.SearchTerm, score: scoreBuilder.Boost(1.0))
+            )
             .MinimumShouldMatch(1);
 
         var books = await _booksCollection
@@ -288,12 +485,111 @@ public class BookDao(IMongoDatabase database, IBookEntityMapper mapper) : IBookD
 
         var mappedBooks = books.Select(mapper.Map).ToList();
 
-        var pagedResult = new PagedResult<Book>(
+        return new PagedResult<Book>(
             mappedBooks,
             totalCount?.Count ?? 0,
             queryParameters.Page,
             queryParameters.PageSize);
+    }
 
-        return pagedResult;
+    private static BsonDocument BuildFilterDocument(ObjectId userId, ReadingStatus? status)
+    {
+        var filters = new BsonArray
+        {
+            new BsonDocument("equals", new BsonDocument
+            {
+                { "path", "UserId" },
+                { "value", userId }
+            })
+        };
+
+        if (status.HasValue)
+        {
+            filters.Add(new BsonDocument("equals", new BsonDocument
+            {
+                { "path", "Status" },
+                { "value", status.Value.ToString() }
+            }));
+        }
+
+        return new BsonDocument("$and", filters);
+    }
+
+    private static BsonDocument BuildTextSearchStage(ObjectId userId, SearchQueryParameters queryParameters)
+    {
+        var compound = new BsonDocument
+        {
+            { "filter", new BsonArray
+                {
+                    new BsonDocument("equals", new BsonDocument
+                    {
+                        { "path", "UserId" },
+                        { "value", userId }
+                    })
+                }
+            },
+            { "should", new BsonArray
+                {
+                    new BsonDocument("text", new BsonDocument
+                    {
+                        { "query", queryParameters.SearchTerm },
+                        { "path", "Title" },
+                        { "score", new BsonDocument("boost", new BsonDocument("value", 8.0)) }
+                    }),
+                    new BsonDocument("text", new BsonDocument
+                    {
+                        { "query", queryParameters.SearchTerm },
+                        { "path", "Authors" },
+                        { "score", new BsonDocument("boost", new BsonDocument("value", 8.0)) }
+                    }),
+                    new BsonDocument("autocomplete", new BsonDocument
+                    {
+                        { "query", queryParameters.SearchTerm },
+                        { "path", "Title" },
+                        { "score", new BsonDocument("boost", new BsonDocument("value", 3.0)) }
+                    }),
+                    new BsonDocument("autocomplete", new BsonDocument
+                    {
+                        { "query", queryParameters.SearchTerm },
+                        { "path", "Authors" },
+                        { "score", new BsonDocument("boost", new BsonDocument("value", 3.0)) }
+                    }),
+                    new BsonDocument("text", new BsonDocument
+                    {
+                        { "query", queryParameters.SearchTerm },
+                        { "path", "Publisher" },
+                        { "score", new BsonDocument("boost", new BsonDocument("value", 5.0)) }
+                    }),
+                    new BsonDocument("text", new BsonDocument
+                    {
+                        { "query", queryParameters.SearchTerm },
+                        { "path", "Tags" },
+                        { "score", new BsonDocument("boost", new BsonDocument("value", 2.0)) }
+                    }),
+                    new BsonDocument("text", new BsonDocument
+                    {
+                        { "query", queryParameters.SearchTerm },
+                        { "path", "Description" }
+                    })
+                }
+            },
+            { "minimumShouldMatch", 1 }
+        };
+
+        if (queryParameters.Status.HasValue)
+        {
+            var filterArray = compound["filter"].AsBsonArray;
+            filterArray.Add(new BsonDocument("equals", new BsonDocument
+            {
+                { "path", "Status" },
+                { "value", queryParameters.Status.Value.ToString() }
+            }));
+        }
+
+        return new BsonDocument("$search", new BsonDocument
+        {
+            { "index", "default" },
+            { "compound", compound }
+        });
     }
 }

--- a/src/Intellishelf.Data/Books/DataAccess/BookDao.cs
+++ b/src/Intellishelf.Data/Books/DataAccess/BookDao.cs
@@ -217,257 +217,56 @@ public class BookDao(IMongoDatabase database, IBookEntityMapper mapper) : IBookD
 
     public async Task<TryResult<PagedResult<Book>>> SearchAsync(string userId, SearchQueryParameters queryParameters)
     {
-        var userObjectId = ObjectId.Parse(userId);
-
-        // Use RRF (Reciprocal Rank Fusion) for hybrid search when embeddings are available
-        if (queryParameters.SearchEmbedding != null && queryParameters.SearchEmbedding.Length > 0)
-        {
-            return await SearchWithRRFAsync(userObjectId, queryParameters);
-        }
-
-        // Fall back to text-only search if no embeddings
-        return await SearchTextOnlyAsync(userObjectId, queryParameters);
-    }
-
-    private async Task<TryResult<PagedResult<Book>>> SearchWithRRFAsync(ObjectId userId, SearchQueryParameters queryParameters)
-    {
-        const int textPriority = 1;    // Lower = higher importance (exact matches ranked higher)
-        const int vectorPriority = 60; // Higher = lower importance (semantic matches ranked lower)
-        const int numCandidates = 100;
-
-        // Build the RRF pipeline using raw BsonDocuments for $vectorSearch support
-        var pipeline = new List<BsonDocument>();
-
-        // 1. Vector Search Pipeline
-        var vectorSearchStage = new BsonDocument("$vectorSearch", new BsonDocument
-        {
-            { "index", "vector_index" },
-            { "path", "Embedding" },
-            { "queryVector", new BsonArray(queryParameters.SearchEmbedding!.Select(f => new BsonDouble(f))) },
-            { "numCandidates", numCandidates },
-            { "limit", queryParameters.PageSize * 2 }, // Get more candidates for better RRF
-            { "filter", BuildFilterDocument(userId, queryParameters.Status) }
-        });
-
-        pipeline.Add(vectorSearchStage);
-
-        // 2. Group into array for ranking
-        pipeline.Add(new BsonDocument("$group", new BsonDocument
-        {
-            { "_id", BsonNull.Value },
-            { "docs", new BsonDocument("$push", "$$ROOT") }
-        }));
-
-        // 3. Unwind with array index for ranking
-        pipeline.Add(new BsonDocument("$unwind", new BsonDocument
-        {
-            { "path", "$docs" },
-            { "includeArrayIndex", "rank" }
-        }));
-
-        // 4. Compute vector search RRF score
-        pipeline.Add(new BsonDocument("$addFields", new BsonDocument
-        {
-            { "vs_score", new BsonDocument("$divide", new BsonArray
-                {
-                    1.0,
-                    new BsonDocument("$add", new BsonArray { "$rank", vectorPriority, 1 })
-                })
-            }
-        }));
-
-        // 5. Project fields with vector score
-        pipeline.Add(new BsonDocument("$project", new BsonDocument
-        {
-            { "vs_score", 1 },
-            { "_id", "$docs._id" },
-            { "Title", "$docs.Title" },
-            { "Authors", "$docs.Authors" },
-            { "Description", "$docs.Description" },
-            { "Publisher", "$docs.Publisher" },
-            { "Tags", "$docs.Tags" },
-            { "Annotation", "$docs.Annotation" },
-            { "Isbn10", "$docs.Isbn10" },
-            { "Isbn13", "$docs.Isbn13" },
-            { "Pages", "$docs.Pages" },
-            { "CoverImageUrl", "$docs.CoverImageUrl" },
-            { "PublicationDate", "$docs.PublicationDate" },
-            { "UserId", "$docs.UserId" },
-            { "Status", "$docs.Status" },
-            { "StartedReadingDate", "$docs.StartedReadingDate" },
-            { "FinishedReadingDate", "$docs.FinishedReadingDate" },
-            { "CreatedDate", "$docs.CreatedDate" },
-            { "ModifiedDate", "$docs.ModifiedDate" },
-            { "Embedding", "$docs.Embedding" }
-        }));
-
-        // 6. Union with text search results
-        var textSearchPipeline = new BsonArray
-        {
-            BuildTextSearchStage(userId, queryParameters),
-            new BsonDocument("$limit", queryParameters.PageSize * 2),
-            new BsonDocument("$group", new BsonDocument
-            {
-                { "_id", BsonNull.Value },
-                { "docs", new BsonDocument("$push", "$$ROOT") }
-            }),
-            new BsonDocument("$unwind", new BsonDocument
-            {
-                { "path", "$docs" },
-                { "includeArrayIndex", "rank" }
-            }),
-            new BsonDocument("$addFields", new BsonDocument
-            {
-                { "ts_score", new BsonDocument("$divide", new BsonArray
-                    {
-                        1.0,
-                        new BsonDocument("$add", new BsonArray { "$rank", textPriority, 1 })
-                    })
-                }
-            }),
-            new BsonDocument("$project", new BsonDocument
-            {
-                { "ts_score", 1 },
-                { "_id", "$docs._id" },
-                { "Title", "$docs.Title" },
-                { "Authors", "$docs.Authors" },
-                { "Description", "$docs.Description" },
-                { "Publisher", "$docs.Publisher" },
-                { "Tags", "$docs.Tags" },
-                { "Annotation", "$docs.Annotation" },
-                { "Isbn10", "$docs.Isbn10" },
-                { "Isbn13", "$docs.Isbn13" },
-                { "Pages", "$docs.Pages" },
-                { "CoverImageUrl", "$docs.CoverImageUrl" },
-                { "PublicationDate", "$docs.PublicationDate" },
-                { "UserId", "$docs.UserId" },
-                { "Status", "$docs.Status" },
-                { "StartedReadingDate", "$docs.StartedReadingDate" },
-                { "FinishedReadingDate", "$docs.FinishedReadingDate" },
-                { "CreatedDate", "$docs.CreatedDate" },
-                { "ModifiedDate", "$docs.ModifiedDate" },
-                { "Embedding", "$docs.Embedding" }
-            })
-        };
-
-        pipeline.Add(new BsonDocument("$unionWith", new BsonDocument
-        {
-            { "coll", BookEntity.CollectionName },
-            { "pipeline", textSearchPipeline }
-        }));
-
-        // 7. Combine scores from both searches (take max for each document)
-        pipeline.Add(new BsonDocument("$group", new BsonDocument
-        {
-            { "_id", "$_id" },
-            { "vs_score", new BsonDocument("$max", "$vs_score") },
-            { "ts_score", new BsonDocument("$max", "$ts_score") },
-            { "Title", new BsonDocument("$first", "$Title") },
-            { "Authors", new BsonDocument("$first", "$Authors") },
-            { "Description", new BsonDocument("$first", "$Description") },
-            { "Publisher", new BsonDocument("$first", "$Publisher") },
-            { "Tags", new BsonDocument("$first", "$Tags") },
-            { "Annotation", new BsonDocument("$first", "$Annotation") },
-            { "Isbn10", new BsonDocument("$first", "$Isbn10") },
-            { "Isbn13", new BsonDocument("$first", "$Isbn13") },
-            { "Pages", new BsonDocument("$first", "$Pages") },
-            { "CoverImageUrl", new BsonDocument("$first", "$CoverImageUrl") },
-            { "PublicationDate", new BsonDocument("$first", "$PublicationDate") },
-            { "UserId", new BsonDocument("$first", "$UserId") },
-            { "Status", new BsonDocument("$first", "$Status") },
-            { "StartedReadingDate", new BsonDocument("$first", "$StartedReadingDate") },
-            { "FinishedReadingDate", new BsonDocument("$first", "$FinishedReadingDate") },
-            { "CreatedDate", new BsonDocument("$first", "$CreatedDate") },
-            { "ModifiedDate", new BsonDocument("$first", "$ModifiedDate") },
-            { "Embedding", new BsonDocument("$first", "$Embedding") }
-        }));
-
-        // 8. Calculate combined RRF score
-        pipeline.Add(new BsonDocument("$project", new BsonDocument
-        {
-            { "_id", 1 },
-            { "Title", 1 },
-            { "Authors", 1 },
-            { "Description", 1 },
-            { "Publisher", 1 },
-            { "Tags", 1 },
-            { "Annotation", 1 },
-            { "Isbn10", 1 },
-            { "Isbn13", 1 },
-            { "Pages", 1 },
-            { "CoverImageUrl", 1 },
-            { "PublicationDate", 1 },
-            { "UserId", 1 },
-            { "Status", 1 },
-            { "StartedReadingDate", 1 },
-            { "FinishedReadingDate", 1 },
-            { "CreatedDate", 1 },
-            { "ModifiedDate", 1 },
-            { "Embedding", 1 },
-            { "score", new BsonDocument("$let", new BsonDocument
-                {
-                    { "vars", new BsonDocument
-                        {
-                            { "vs_score", new BsonDocument("$ifNull", new BsonArray { "$vs_score", 0.0 }) },
-                            { "ts_score", new BsonDocument("$ifNull", new BsonArray { "$ts_score", 0.0 }) }
-                        }
-                    },
-                    { "in", new BsonDocument("$add", new BsonArray { "$$vs_score", "$$ts_score" }) }
-                })
-            }
-        }));
-
-        // 9. Sort by combined score (descending)
-        pipeline.Add(new BsonDocument("$sort", new BsonDocument("score", -1)));
-
-        // 10. Pagination
-        pipeline.Add(new BsonDocument("$skip", (queryParameters.Page - 1) * queryParameters.PageSize));
-        pipeline.Add(new BsonDocument("$limit", queryParameters.PageSize));
-
-        // Execute the aggregation
-        var books = await _booksCollection.Aggregate<BookEntity>(pipeline).ToListAsync();
-        var mappedBooks = books.Select(mapper.Map).ToList();
-
-        // Get total count (simplified - could be optimized)
-        var totalCount = mappedBooks.Count; // For now, use result count. TODO: Add proper count pipeline
-
-        return new PagedResult<Book>(
-            mappedBooks,
-            totalCount,
-            queryParameters.Page,
-            queryParameters.PageSize);
-    }
-
-    private async Task<TryResult<PagedResult<Book>>> SearchTextOnlyAsync(ObjectId userId, SearchQueryParameters queryParameters)
-    {
         var scoreBuilder = Builders<BookEntity>.SearchScore;
         var searchBuilder = Builders<BookEntity>.Search;
+        var userObjectId = ObjectId.Parse(userId);
+
         var looseFuzzy = new SearchFuzzyOptions { MaxEdits = 1, PrefixLength = 2 };
 
         var compoundBuilder = searchBuilder
             .Compound()
-            .Filter(searchBuilder.Equals(f => f.UserId, userId));
+            .Filter(searchBuilder.Equals(f => f.UserId, userObjectId));
 
+        // Add status filter if provided
         if (queryParameters.Status.HasValue)
         {
             compoundBuilder = compoundBuilder.Filter(searchBuilder.Equals(f => f.Status, queryParameters.Status.Value));
         }
 
+        // Build text search clauses
+        var shouldClauses = new List<SearchDefinition<BookEntity>>
+        {
+            searchBuilder.Autocomplete(f => f.Title, queryParameters.SearchTerm, score: scoreBuilder.Boost(3.0)),
+            searchBuilder.Text(f => f.Title, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)),
+            searchBuilder.Text(f => f.Title, queryParameters.SearchTerm, fuzzy: looseFuzzy, score: scoreBuilder.Boost(2.0)),
+            searchBuilder.Autocomplete(f => f.Authors, queryParameters.SearchTerm, score: scoreBuilder.Boost(3.0)),
+            searchBuilder.Text(f => f.Authors, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)),
+            searchBuilder.Text(f => f.Authors, queryParameters.SearchTerm, fuzzy: looseFuzzy, score: scoreBuilder.Boost(2.0)),
+            searchBuilder.Autocomplete(f => f.Publisher, queryParameters.SearchTerm, score: scoreBuilder.Boost(3.0)),
+            searchBuilder.Text(f => f.Publisher, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)),
+            searchBuilder.Text(f => f.Publisher, queryParameters.SearchTerm, fuzzy: looseFuzzy, score: scoreBuilder.Boost(2.0)),
+            searchBuilder.Text(f => f.Tags, queryParameters.SearchTerm, score: scoreBuilder.Boost(2.0)),
+            searchBuilder.Text(f => f.Description, queryParameters.SearchTerm, score: scoreBuilder.Boost(1.0)),
+            searchBuilder.Text(f => f.Annotation, queryParameters.SearchTerm, score: scoreBuilder.Boost(1.0))
+        };
+
+        // Add vector search if embeddings are available
+        // Vector search is combined with text search in a single compound query for hybrid results
+        // Books matching both text and semantic meaning will score highest
+        if (queryParameters.SearchEmbedding != null && queryParameters.SearchEmbedding.Length > 0)
+        {
+            shouldClauses.Add(
+                searchBuilder.KnnVector(
+                    f => f.Embedding,
+                    queryParameters.SearchEmbedding,
+                    100, // Number of candidates to consider
+                    score: scoreBuilder.Boost(10.0) // Boost vector search to balance with text scores
+                )
+            );
+        }
+
         var searchFilter = compoundBuilder
-            .Should(
-                searchBuilder.Autocomplete(f => f.Title, queryParameters.SearchTerm, score: scoreBuilder.Boost(3.0)),
-                searchBuilder.Text(f => f.Title, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)),
-                searchBuilder.Text(f => f.Title, queryParameters.SearchTerm, fuzzy: looseFuzzy, score: scoreBuilder.Boost(2.0)),
-                searchBuilder.Autocomplete(f => f.Authors, queryParameters.SearchTerm, score: scoreBuilder.Boost(3.0)),
-                searchBuilder.Text(f => f.Authors, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)),
-                searchBuilder.Text(f => f.Authors, queryParameters.SearchTerm, fuzzy: looseFuzzy, score: scoreBuilder.Boost(2.0)),
-                searchBuilder.Autocomplete(f => f.Publisher, queryParameters.SearchTerm, score: scoreBuilder.Boost(3.0)),
-                searchBuilder.Text(f => f.Publisher, queryParameters.SearchTerm, score: scoreBuilder.Boost(8.0)),
-                searchBuilder.Text(f => f.Publisher, queryParameters.SearchTerm, fuzzy: looseFuzzy, score: scoreBuilder.Boost(2.0)),
-                searchBuilder.Text(f => f.Tags, queryParameters.SearchTerm, score: scoreBuilder.Boost(2.0)),
-                searchBuilder.Text(f => f.Description, queryParameters.SearchTerm, score: scoreBuilder.Boost(1.0)),
-                searchBuilder.Text(f => f.Annotation, queryParameters.SearchTerm, score: scoreBuilder.Boost(1.0))
-            )
+            .Should(shouldClauses.ToArray())
             .MinimumShouldMatch(1);
 
         var books = await _booksCollection
@@ -485,111 +284,12 @@ public class BookDao(IMongoDatabase database, IBookEntityMapper mapper) : IBookD
 
         var mappedBooks = books.Select(mapper.Map).ToList();
 
-        return new PagedResult<Book>(
+        var pagedResult = new PagedResult<Book>(
             mappedBooks,
             totalCount?.Count ?? 0,
             queryParameters.Page,
             queryParameters.PageSize);
-    }
 
-    private static BsonDocument BuildFilterDocument(ObjectId userId, ReadingStatus? status)
-    {
-        var filters = new BsonArray
-        {
-            new BsonDocument("equals", new BsonDocument
-            {
-                { "path", "UserId" },
-                { "value", userId }
-            })
-        };
-
-        if (status.HasValue)
-        {
-            filters.Add(new BsonDocument("equals", new BsonDocument
-            {
-                { "path", "Status" },
-                { "value", status.Value.ToString() }
-            }));
-        }
-
-        return new BsonDocument("$and", filters);
-    }
-
-    private static BsonDocument BuildTextSearchStage(ObjectId userId, SearchQueryParameters queryParameters)
-    {
-        var compound = new BsonDocument
-        {
-            { "filter", new BsonArray
-                {
-                    new BsonDocument("equals", new BsonDocument
-                    {
-                        { "path", "UserId" },
-                        { "value", userId }
-                    })
-                }
-            },
-            { "should", new BsonArray
-                {
-                    new BsonDocument("text", new BsonDocument
-                    {
-                        { "query", queryParameters.SearchTerm },
-                        { "path", "Title" },
-                        { "score", new BsonDocument("boost", new BsonDocument("value", 8.0)) }
-                    }),
-                    new BsonDocument("text", new BsonDocument
-                    {
-                        { "query", queryParameters.SearchTerm },
-                        { "path", "Authors" },
-                        { "score", new BsonDocument("boost", new BsonDocument("value", 8.0)) }
-                    }),
-                    new BsonDocument("autocomplete", new BsonDocument
-                    {
-                        { "query", queryParameters.SearchTerm },
-                        { "path", "Title" },
-                        { "score", new BsonDocument("boost", new BsonDocument("value", 3.0)) }
-                    }),
-                    new BsonDocument("autocomplete", new BsonDocument
-                    {
-                        { "query", queryParameters.SearchTerm },
-                        { "path", "Authors" },
-                        { "score", new BsonDocument("boost", new BsonDocument("value", 3.0)) }
-                    }),
-                    new BsonDocument("text", new BsonDocument
-                    {
-                        { "query", queryParameters.SearchTerm },
-                        { "path", "Publisher" },
-                        { "score", new BsonDocument("boost", new BsonDocument("value", 5.0)) }
-                    }),
-                    new BsonDocument("text", new BsonDocument
-                    {
-                        { "query", queryParameters.SearchTerm },
-                        { "path", "Tags" },
-                        { "score", new BsonDocument("boost", new BsonDocument("value", 2.0)) }
-                    }),
-                    new BsonDocument("text", new BsonDocument
-                    {
-                        { "query", queryParameters.SearchTerm },
-                        { "path", "Description" }
-                    })
-                }
-            },
-            { "minimumShouldMatch", 1 }
-        };
-
-        if (queryParameters.Status.HasValue)
-        {
-            var filterArray = compound["filter"].AsBsonArray;
-            filterArray.Add(new BsonDocument("equals", new BsonDocument
-            {
-                { "path", "Status" },
-                { "value", queryParameters.Status.Value.ToString() }
-            }));
-        }
-
-        return new BsonDocument("$search", new BsonDocument
-        {
-            { "index", "default" },
-            { "compound", compound }
-        });
+        return pagedResult;
     }
 }

--- a/src/Intellishelf.Data/Books/Entities/BookEntity.cs
+++ b/src/Intellishelf.Data/Books/Entities/BookEntity.cs
@@ -20,6 +20,7 @@ public class BookEntity : EntityBase
     public string? Annotation { get; init; }
     public string? Description { get; init; }
     public string[]? Tags { get; init; }
+    public float[]? Embedding { get; init; }
     public required DateTime CreatedDate { get; init; }
     public required DateTime ModifiedDate { get; init; }
 

--- a/src/Intellishelf.Data/Books/Mappers/BookEntityMapper.cs
+++ b/src/Intellishelf.Data/Books/Mappers/BookEntityMapper.cs
@@ -22,6 +22,7 @@ public class BookEntityMapper : IBookEntityMapper
             CoverImageUrl = bookEntity.CoverImageUrl,
             CreatedDate = bookEntity.CreatedDate,
             Tags = bookEntity.Tags,
+            Embedding = bookEntity.Embedding,
             Status = bookEntity.Status,
             StartedReadingDate = bookEntity.StartedReadingDate,
             FinishedReadingDate = bookEntity.FinishedReadingDate

--- a/src/Intellishelf.Domain/Ai/Services/AiService.cs
+++ b/src/Intellishelf.Domain/Ai/Services/AiService.cs
@@ -1,12 +1,14 @@
+using System.Text;
 using System.Text.Json;
 using Intellishelf.Common.TryResult;
 using Intellishelf.Domain.Ai.Errors;
 using Intellishelf.Domain.Books.Models;
 using OpenAI.Chat;
+using OpenAI.Embeddings;
 
 namespace Intellishelf.Domain.Ai.Services;
 
-public class AiService(ChatClient chatClient) : IAiService
+public class AiService(ChatClient chatClient, EmbeddingClient embeddingClient) : IAiService
 {
     private const string Prompt =
         "You are a book page parser. You are given a verso book page which may include all information about book. I want to add it to my personal library. Extract content language, title, authors (via CSV if multiple), publisher, publicationYear, pages, isbn10, isbn13, description. Language of content may be any so find out yourself. Don't translate content, don't rephrase content, just parse. If you can't determine property, set null instead of improvising";
@@ -92,6 +94,52 @@ public class AiService(ChatClient chatClient) : IAiService
         {
             return new Error(AiErrorCodes.RequestFailed, e.Message);
         }
+    }
 
+    public async Task<TryResult<float[]>> GenerateEmbeddingAsync(Book book, bool useMockedAi = false)
+    {
+        if (useMockedAi)
+        {
+            // Return a mock embedding vector (3072 dimensions for text-embedding-3-large)
+            var mockEmbedding = new float[3072];
+            Array.Fill(mockEmbedding, 0.1f);
+            return mockEmbedding;
+        }
+
+        try
+        {
+            var textToEmbed = FormatBookForEmbedding(book);
+            var embeddingResponse = await embeddingClient.GenerateEmbeddingAsync(textToEmbed);
+            var embedding = embeddingResponse.Value.ToFloats().ToArray();
+            return embedding;
+        }
+        catch (Exception e)
+        {
+            return new Error(AiErrorCodes.RequestFailed, $"Failed to generate embedding: {e.Message}");
+        }
+    }
+
+    private static string FormatBookForEmbedding(Book book)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(book.Title);
+        sb.AppendLine($"Title: {book.Title}");
+
+        if (!string.IsNullOrWhiteSpace(book.Authors))
+            sb.AppendLine($"Author: {book.Authors}");
+
+        // Note: The codebase doesn't have Genres field currently
+        // If needed, this can be derived from Tags or added as a separate field
+
+        if (book.PublicationDate.HasValue)
+            sb.AppendLine($"Year of publication: {book.PublicationDate.Value.Year}");
+
+        if (book.Tags is { Length: > 0 })
+            sb.AppendLine($"Tags: {string.Join(", ", book.Tags)}");
+
+        if (!string.IsNullOrWhiteSpace(book.Description))
+            sb.AppendLine($"Description: {book.Description}");
+
+        return sb.ToString();
     }
 }

--- a/src/Intellishelf.Domain/Ai/Services/IAiService.cs
+++ b/src/Intellishelf.Domain/Ai/Services/IAiService.cs
@@ -6,4 +6,5 @@ namespace Intellishelf.Domain.Ai.Services;
 public interface IAiService
 {
     Task<TryResult<ParsedBook>> ParseBookFromTextAsync(string text, bool useMockedAi);
+    Task<TryResult<float[]>> GenerateEmbeddingAsync(Book book, bool useMockedAi = false);
 }

--- a/src/Intellishelf.Domain/Books/DataAccess/IBookDao.cs
+++ b/src/Intellishelf.Domain/Books/DataAccess/IBookDao.cs
@@ -17,6 +17,8 @@ public interface IBookDao
 
     Task<TryResult> TryUpdateBookAsync(UpdateBookRequest request);
 
+    Task<TryResult> UpdateEmbeddingAsync(string userId, string bookId, float[] embedding);
+
     Task<TryResult> DeleteBookAsync(string userId, string bookId);
 
     Task<TryResult<PagedResult<Book>>> SearchAsync(string userId, SearchQueryParameters queryParameters);

--- a/src/Intellishelf.Domain/Books/Models/Book.cs
+++ b/src/Intellishelf.Domain/Books/Models/Book.cs
@@ -3,11 +3,11 @@ namespace Intellishelf.Domain.Books.Models;
 public class Book
 {
     public string Id { get; init; } = null!;
-    
+
     public required DateTime CreatedDate { get; init; }
     public required string Title { get; init; }
     public required string UserId { get; init; }
-    
+
     public string? Annotation { get; init; }
     public string? Authors { get; init; }
     public string? Description { get; init; }
@@ -18,6 +18,7 @@ public class Book
     public DateTime? PublicationDate { get; init; }
     public string? Publisher { get; init; }
     public string[]? Tags { get; init; }
+    public float[]? Embedding { get; init; }
 
     public ReadingStatus Status { get; init; }
     public DateTime? StartedReadingDate { get; init; }

--- a/src/Intellishelf.Domain/Books/Models/SearchQueryParameters.cs
+++ b/src/Intellishelf.Domain/Books/Models/SearchQueryParameters.cs
@@ -18,4 +18,6 @@ public class SearchQueryParameters
     }
 
     public ReadingStatus? Status { get; init; }
+
+    public float[]? SearchEmbedding { get; init; }
 }


### PR DESCRIPTION
Implemented automatic embedding generation for books using OpenAI's text-embedding-3-large model. Embeddings are generated automatically when books are added or updated, and are stored in MongoDB for vector similarity search.

Changes:
- Added EmbeddingClient configuration in AiModule using text-embedding-3-large
- Updated BookEntity and Book models to include Embedding field (float[])
- Added GenerateEmbeddingAsync method to IAiService and AiService
  - Formats book data as: Title, Author, Year of Publication, Tags, Description
  - Returns 3072-dimensional embeddings
- Updated BookService to automatically generate embeddings on add/update operations
- Enhanced search functionality with hybrid text + vector similarity search
- Added UpdateEmbeddingAsync method to IBookDao for efficient embedding updates
- Updated SearchQueryParameters to support optional SearchEmbedding field
- Modified BookDao.SearchAsync to combine text search with KNN vector search

Vector search requires MongoDB Atlas vector search index:
- Index name: vector_index
- Field: Embedding
- Dimensions: 3072
- Similarity: cosine

All embedding operations are non-blocking - if embedding generation fails, the book operation still succeeds.