### PR TITLE
Add updated UI design with loader component

### DIFF
--- a/frontend-v2/src/components/BookCard.tsx
+++ b/frontend-v2/src/components/BookCard.tsx
@@ -28,9 +28,10 @@ import StatusBadge from './books/StatusBadge';
 interface BookCardProps {
   book: Book;
   onClick?: () => void;
+  viewMode?: 'grid' | 'list';
 }
 
-const BookCard = ({ book, onClick }: BookCardProps) => {
+const BookCard = ({ book, onClick, viewMode = 'grid' }: BookCardProps) => {
   const navigate = useNavigate();
   const { mutate: deleteBook } = useDeleteBook();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
@@ -62,6 +63,105 @@ const BookCard = ({ book, onClick }: BookCardProps) => {
     setShowDeleteDialog(false);
   };
 
+  // List view layout
+  if (viewMode === 'list') {
+    return (
+      <>
+        <Card
+          className='bg-book-card hover:bg-book-card-hover border-border transition-all cursor-pointer group overflow-hidden'
+          onClick={handleClick}
+        >
+          <div className='flex gap-4 p-4'>
+            <div className='w-24 h-36 relative overflow-hidden bg-secondary rounded flex-shrink-0'>
+              {book.coverImageUrl ? (
+                <img
+                  src={book.coverImageUrl}
+                  alt={book.title}
+                  className='w-full h-full object-cover group-hover:scale-105 transition-transform duration-300'
+                />
+              ) : (
+                <div className='w-full h-full flex items-center justify-center'>
+                  <span className='text-muted-foreground text-xs'>No cover</span>
+                </div>
+              )}
+
+              {/* Hover overlay with actions */}
+              <div className='absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-2'>
+                <Button size='sm' variant='secondary' onClick={handleEdit}>
+                  <Edit className='w-3 h-3' />
+                </Button>
+                <Button size='sm' variant='destructive' onClick={handleDelete}>
+                  <Trash className='w-3 h-3' />
+                </Button>
+              </div>
+            </div>
+
+            <div className='flex-1 flex flex-col justify-center min-w-0 gap-2'>
+              <div>
+                <h3 className='font-semibold text-foreground text-lg mb-1 line-clamp-1'>
+                  {book.title}
+                </h3>
+                <p className='text-sm text-muted-foreground line-clamp-1'>
+                  {book.authors || 'Unknown Author'}
+                </p>
+              </div>
+
+              <div className='flex items-center gap-2'>
+                <StatusBadge status={book.status} />
+              </div>
+
+              {book.description && (
+                <p className='text-sm text-muted-foreground/80 line-clamp-2'>
+                  {book.description}
+                </p>
+              )}
+
+              <div className='flex items-center gap-4 text-xs text-muted-foreground mt-auto'>
+                {book.publicationDate && (
+                  <span>Published {new Date(book.publicationDate).getFullYear()}</span>
+                )}
+                <span>Added {new Date(book.createdDate).toLocaleDateString()}</span>
+              </div>
+            </div>
+          </div>
+        </Card>
+
+        {/* Edit dialog */}
+        <Dialog open={showEditDialog} onOpenChange={setShowEditDialog}>
+          <DialogContent className='max-w-2xl max-h-[90vh] overflow-y-auto'>
+            <DialogHeader>
+              <DialogTitle>Edit Book</DialogTitle>
+            </DialogHeader>
+            <BookForm
+              book={book}
+              onSuccess={() => setShowEditDialog(false)}
+            />
+          </DialogContent>
+        </Dialog>
+
+        {/* Delete confirmation dialog */}
+        <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete "{book.title}"?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This action cannot be undone. This will permanently delete the book
+                from your library.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={confirmDelete}>
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </>
+    );
+  }
+
+  // Grid view layout (default)
   return (
     <>
       <Card

--- a/frontend-v2/src/pages/BookDetail.tsx
+++ b/frontend-v2/src/pages/BookDetail.tsx
@@ -1,9 +1,12 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { ArrowLeft, BookOpen, Calendar, Trash2, Edit } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { ArrowLeft, BookOpen, Calendar, Trash2, Edit, Save, X } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   AlertDialog,
@@ -15,28 +18,53 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
 import { useBook } from '@/hooks/books/useBook';
 import { useDeleteBook } from '@/hooks/books/useDeleteBook';
+import { useUpdateBook } from '@/hooks/books/useUpdateBook';
 import { useBookCoverColor } from '@/hooks/utils/useBookCoverColor';
 import StatusBadge from '@/components/books/StatusBadge';
-import BookForm from '@/components/books/BookForm';
 
 const BookDetail = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { data: book, isLoading } = useBook(id!);
   const { mutate: deleteBook } = useDeleteBook();
+  const { mutate: updateBook } = useUpdateBook();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-  const [showEditDialog, setShowEditDialog] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+
+  // Edit form state
+  const [editForm, setEditForm] = useState({
+    title: '',
+    authors: '',
+    publisher: '',
+    publicationDate: '',
+    isbn10: '',
+    isbn13: '',
+    pages: '',
+    description: '',
+    annotation: '',
+  });
 
   // Extract dominant color from book cover
   const dominantColor = useBookCoverColor(book?.coverImageUrl);
+
+  // Sync form with book data
+  useEffect(() => {
+    if (book) {
+      setEditForm({
+        title: book.title || '',
+        authors: book.authors || '',
+        publisher: book.publisher || '',
+        publicationDate: book.publicationDate || '',
+        isbn10: book.isbn10 || '',
+        isbn13: book.isbn13 || '',
+        pages: book.pages?.toString() || '',
+        description: book.description || '',
+        annotation: book.annotation || '',
+      });
+    }
+  }, [book]);
 
   const handleDelete = () => {
     deleteBook(id!, {
@@ -44,6 +72,45 @@ const BookDetail = () => {
         navigate('/');
       },
     });
+  };
+
+  const handleSave = () => {
+    updateBook({
+      id: id!,
+      data: {
+        title: editForm.title,
+        authors: editForm.authors,
+        publisher: editForm.publisher || undefined,
+        publicationDate: editForm.publicationDate || undefined,
+        isbn10: editForm.isbn10 || undefined,
+        isbn13: editForm.isbn13 || undefined,
+        pages: editForm.pages ? parseInt(editForm.pages, 10) : undefined,
+        description: editForm.description || undefined,
+        annotation: editForm.annotation || undefined,
+        status: book!.status,
+      },
+    }, {
+      onSuccess: () => {
+        setIsEditing(false);
+      },
+    });
+  };
+
+  const handleCancel = () => {
+    if (book) {
+      setEditForm({
+        title: book.title || '',
+        authors: book.authors || '',
+        publisher: book.publisher || '',
+        publicationDate: book.publicationDate || '',
+        isbn10: book.isbn10 || '',
+        isbn13: book.isbn13 || '',
+        pages: book.pages?.toString() || '',
+        description: book.description || '',
+        annotation: book.annotation || '',
+      });
+    }
+    setIsEditing(false);
   };
 
   if (isLoading) {
@@ -122,187 +189,295 @@ const BookDetail = () => {
               </Card>
 
               {/* Action Buttons */}
-              <div className='flex gap-2 mt-6'>
-                <Button
-                  variant='outline'
-                  size='sm'
-                  className='flex-1'
-                  onClick={() => setShowEditDialog(true)}
-                >
-                  <Edit className='w-4 h-4' />
-                </Button>
-                <Button
-                  variant='outline'
-                  size='sm'
-                  className='flex-1'
-                  onClick={() => setShowDeleteDialog(true)}
-                >
-                  <Trash2 className='w-4 h-4' />
-                </Button>
-              </div>
+              {isEditing ? (
+                <div className='flex gap-2 mt-6'>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    className='flex-1'
+                    onClick={handleSave}
+                  >
+                    <Save className='w-4 h-4' />
+                  </Button>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    className='flex-1'
+                    onClick={handleCancel}
+                  >
+                    <X className='w-4 h-4' />
+                  </Button>
+                </div>
+              ) : (
+                <div className='flex gap-2 mt-6'>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    className='flex-1'
+                    onClick={() => setIsEditing(true)}
+                  >
+                    <Edit className='w-4 h-4' />
+                  </Button>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    className='flex-1'
+                    onClick={() => setShowDeleteDialog(true)}
+                  >
+                    <Trash2 className='w-4 h-4' />
+                  </Button>
+                </div>
+              )}
             </div>
 
             {/* Book Details */}
             <div className='space-y-6'>
-              <div>
-                <h1 className='text-5xl font-bold text-foreground mb-3 leading-tight'>
-                  {book.title}
-                </h1>
-                <p className='text-2xl text-muted-foreground mb-6'>
-                  {book.authors || 'Unknown Author'}
-                </p>
+              {isEditing ? (
+                /* Edit Mode - Form Fields */
+                <div className='space-y-4'>
+                  <div>
+                    <Label htmlFor='title'>Title</Label>
+                    <Input
+                      id='title'
+                      value={editForm.title}
+                      onChange={(e) => setEditForm({ ...editForm, title: e.target.value })}
+                      className='text-2xl font-bold mt-1'
+                    />
+                  </div>
 
-                <div className='flex flex-wrap gap-2'>
-                  <StatusBadge status={book.status} />
-                  {book.publicationDate && (
-                    <Badge
-                      variant='secondary'
-                      className='text-sm backdrop-blur-sm'
-                      style={{
-                        background: `hsl(var(--book-color) / 0.15)`,
-                        borderColor: `hsl(var(--book-color) / 0.3)`
-                      }}
-                    >
-                      <Calendar className='w-3 h-3 mr-1' />
-                      {new Date(book.publicationDate).getFullYear()}
-                    </Badge>
-                  )}
-                  {book.isbn10 && (
-                    <Badge
-                      variant='secondary'
-                      className='text-sm backdrop-blur-sm'
-                      style={{
-                        background: `hsl(var(--book-color) / 0.15)`,
-                        borderColor: `hsl(var(--book-color) / 0.3)`
-                      }}
-                    >
-                      ISBN-10: {book.isbn10}
-                    </Badge>
-                  )}
-                  {book.isbn13 && (
-                    <Badge
-                      variant='secondary'
-                      className='text-sm backdrop-blur-sm'
-                      style={{
-                        background: `hsl(var(--book-color) / 0.15)`,
-                        borderColor: `hsl(var(--book-color) / 0.3)`
-                      }}
-                    >
-                      ISBN-13: {book.isbn13}
-                    </Badge>
-                  )}
+                  <div>
+                    <Label htmlFor='authors'>Author(s)</Label>
+                    <Input
+                      id='authors'
+                      value={editForm.authors}
+                      onChange={(e) => setEditForm({ ...editForm, authors: e.target.value })}
+                      className='text-lg mt-1'
+                    />
+                  </div>
+
+                  <div>
+                    <Label htmlFor='publisher'>Publisher</Label>
+                    <Input
+                      id='publisher'
+                      value={editForm.publisher}
+                      onChange={(e) => setEditForm({ ...editForm, publisher: e.target.value })}
+                      className='mt-1'
+                    />
+                  </div>
+
+                  <div>
+                    <Label htmlFor='publicationDate'>Publication Date</Label>
+                    <Input
+                      id='publicationDate'
+                      type='date'
+                      value={editForm.publicationDate}
+                      onChange={(e) => setEditForm({ ...editForm, publicationDate: e.target.value })}
+                      className='mt-1'
+                    />
+                  </div>
+
+                  <div>
+                    <Label htmlFor='isbn10'>ISBN-10</Label>
+                    <Input
+                      id='isbn10'
+                      value={editForm.isbn10}
+                      onChange={(e) => setEditForm({ ...editForm, isbn10: e.target.value })}
+                      className='mt-1'
+                    />
+                  </div>
+
+                  <div>
+                    <Label htmlFor='isbn13'>ISBN-13</Label>
+                    <Input
+                      id='isbn13'
+                      value={editForm.isbn13}
+                      onChange={(e) => setEditForm({ ...editForm, isbn13: e.target.value })}
+                      className='mt-1'
+                    />
+                  </div>
+
+                  <div>
+                    <Label htmlFor='pages'>Pages</Label>
+                    <Input
+                      id='pages'
+                      type='number'
+                      value={editForm.pages}
+                      onChange={(e) => setEditForm({ ...editForm, pages: e.target.value })}
+                      className='mt-1'
+                    />
+                  </div>
+
+                  <div>
+                    <Label htmlFor='description'>Description</Label>
+                    <Textarea
+                      id='description'
+                      value={editForm.description}
+                      onChange={(e) => setEditForm({ ...editForm, description: e.target.value })}
+                      className='mt-1 min-h-[120px]'
+                    />
+                  </div>
+
+                  <div>
+                    <Label htmlFor='annotation'>Personal Notes</Label>
+                    <Textarea
+                      id='annotation'
+                      value={editForm.annotation}
+                      onChange={(e) => setEditForm({ ...editForm, annotation: e.target.value })}
+                      className='mt-1 min-h-[120px]'
+                    />
+                  </div>
                 </div>
-              </div>
-
-              {/* Information */}
-              <div className='space-y-4 text-foreground/90'>
-                <div>
-                  <p className='text-sm text-muted-foreground mb-1'>Author(s)</p>
-                  <p className='text-lg'>{book.authors || 'Unknown'}</p>
-                </div>
-
-                {book.publisher && (
+              ) : (
+                /* View Mode - Display Only */
+                <>
                   <div>
-                    <p className='text-sm text-muted-foreground mb-1'>Publisher</p>
-                    <p className='text-lg'>{book.publisher}</p>
-                  </div>
-                )}
-
-                {book.publicationDate && (
-                  <div>
-                    <p className='text-sm text-muted-foreground mb-1'>Publication Date</p>
-                    <p className='text-lg'>
-                      {new Date(book.publicationDate).toLocaleDateString()}
+                    <h1 className='text-5xl font-bold text-foreground mb-3 leading-tight'>
+                      {book.title}
+                    </h1>
+                    <p className='text-2xl text-muted-foreground mb-6'>
+                      {book.authors || 'Unknown Author'}
                     </p>
-                  </div>
-                )}
 
-                {book.pages && (
-                  <div>
-                    <p className='text-sm text-muted-foreground mb-1'>Pages</p>
-                    <p className='text-lg'>{book.pages}</p>
-                  </div>
-                )}
-
-                <div>
-                  <p className='text-sm text-muted-foreground mb-1'>Date Added</p>
-                  <p className='text-lg'>
-                    {new Date(book.createdDate).toLocaleDateString()}
-                  </p>
-                </div>
-
-                {book.startedReadingDate && (
-                  <div>
-                    <p className='text-sm text-muted-foreground mb-1'>Started Reading</p>
-                    <p className='text-lg'>
-                      {new Date(book.startedReadingDate).toLocaleDateString()}
-                    </p>
-                  </div>
-                )}
-
-                {book.finishedReadingDate && (
-                  <div>
-                    <p className='text-sm text-muted-foreground mb-1'>Finished Reading</p>
-                    <p className='text-lg'>
-                      {new Date(book.finishedReadingDate).toLocaleDateString()}
-                    </p>
-                  </div>
-                )}
-
-                {book.tags && book.tags.length > 0 && (
-                  <div>
-                    <p className='text-sm text-muted-foreground mb-1'>Tags</p>
-                    <div className='flex flex-wrap gap-2 mt-1'>
-                      {book.tags.map((tag, index) => (
-                        <Badge key={index} variant='outline'>
-                          {tag}
+                    <div className='flex flex-wrap gap-2'>
+                      <StatusBadge status={book.status} />
+                      {book.publicationDate && (
+                        <Badge
+                          variant='secondary'
+                          className='text-sm backdrop-blur-sm'
+                          style={{
+                            background: `hsl(var(--book-color) / 0.15)`,
+                            borderColor: `hsl(var(--book-color) / 0.3)`
+                          }}
+                        >
+                          <Calendar className='w-3 h-3 mr-1' />
+                          {new Date(book.publicationDate).getFullYear()}
                         </Badge>
-                      ))}
+                      )}
+                      {book.isbn10 && (
+                        <Badge
+                          variant='secondary'
+                          className='text-sm backdrop-blur-sm'
+                          style={{
+                            background: `hsl(var(--book-color) / 0.15)`,
+                            borderColor: `hsl(var(--book-color) / 0.3)`
+                          }}
+                        >
+                          ISBN-10: {book.isbn10}
+                        </Badge>
+                      )}
+                      {book.isbn13 && (
+                        <Badge
+                          variant='secondary'
+                          className='text-sm backdrop-blur-sm'
+                          style={{
+                            background: `hsl(var(--book-color) / 0.15)`,
+                            borderColor: `hsl(var(--book-color) / 0.3)`
+                          }}
+                        >
+                          ISBN-13: {book.isbn13}
+                        </Badge>
+                      )}
                     </div>
                   </div>
-                )}
-              </div>
 
-              {/* Description */}
-              {book.description && (
-                <div className='pt-6 border-t border-border/30'>
-                  <h2 className='text-lg font-semibold text-foreground mb-3'>
-                    Description
-                  </h2>
-                  <p className='text-foreground/80 leading-relaxed whitespace-pre-wrap'>
-                    {book.description}
-                  </p>
-                </div>
-              )}
+                  {/* Information */}
+                  <div className='space-y-4 text-foreground/90'>
+                    <div>
+                      <p className='text-sm text-muted-foreground mb-1'>Author(s)</p>
+                      <p className='text-lg'>{book.authors || 'Unknown'}</p>
+                    </div>
 
-              {/* Personal Notes */}
-              {book.annotation && (
-                <div className='pt-6 border-t border-border/30'>
-                  <h2 className='text-lg font-semibold text-foreground mb-3'>
-                    Personal Notes
-                  </h2>
-                  <p className='text-foreground/80 leading-relaxed whitespace-pre-wrap'>
-                    {book.annotation}
-                  </p>
-                </div>
+                    {book.publisher && (
+                      <div>
+                        <p className='text-sm text-muted-foreground mb-1'>Publisher</p>
+                        <p className='text-lg'>{book.publisher}</p>
+                      </div>
+                    )}
+
+                    {book.publicationDate && (
+                      <div>
+                        <p className='text-sm text-muted-foreground mb-1'>Publication Date</p>
+                        <p className='text-lg'>
+                          {new Date(book.publicationDate).toLocaleDateString()}
+                        </p>
+                      </div>
+                    )}
+
+                    {book.pages && (
+                      <div>
+                        <p className='text-sm text-muted-foreground mb-1'>Pages</p>
+                        <p className='text-lg'>{book.pages}</p>
+                      </div>
+                    )}
+
+                    <div>
+                      <p className='text-sm text-muted-foreground mb-1'>Date Added</p>
+                      <p className='text-lg'>
+                        {new Date(book.createdDate).toLocaleDateString()}
+                      </p>
+                    </div>
+
+                    {book.startedReadingDate && (
+                      <div>
+                        <p className='text-sm text-muted-foreground mb-1'>Started Reading</p>
+                        <p className='text-lg'>
+                          {new Date(book.startedReadingDate).toLocaleDateString()}
+                        </p>
+                      </div>
+                    )}
+
+                    {book.finishedReadingDate && (
+                      <div>
+                        <p className='text-sm text-muted-foreground mb-1'>Finished Reading</p>
+                        <p className='text-lg'>
+                          {new Date(book.finishedReadingDate).toLocaleDateString()}
+                        </p>
+                      </div>
+                    )}
+
+                    {book.tags && book.tags.length > 0 && (
+                      <div>
+                        <p className='text-sm text-muted-foreground mb-1'>Tags</p>
+                        <div className='flex flex-wrap gap-2 mt-1'>
+                          {book.tags.map((tag, index) => (
+                            <Badge key={index} variant='outline'>
+                              {tag}
+                            </Badge>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Description */}
+                  {book.description && (
+                    <div className='pt-6 border-t border-border/30'>
+                      <h2 className='text-lg font-semibold text-foreground mb-3'>
+                        Description
+                      </h2>
+                      <p className='text-foreground/80 leading-relaxed whitespace-pre-wrap'>
+                        {book.description}
+                      </p>
+                    </div>
+                  )}
+
+                  {/* Personal Notes */}
+                  {book.annotation && (
+                    <div className='pt-6 border-t border-border/30'>
+                      <h2 className='text-lg font-semibold text-foreground mb-3'>
+                        Personal Notes
+                      </h2>
+                      <p className='text-foreground/80 leading-relaxed whitespace-pre-wrap'>
+                        {book.annotation}
+                      </p>
+                    </div>
+                  )}
+                </>
               )}
             </div>
           </div>
         </div>
       </div>
-
-      {/* Edit Dialog */}
-      <Dialog open={showEditDialog} onOpenChange={setShowEditDialog}>
-        <DialogContent className='max-w-2xl max-h-[90vh] overflow-y-auto'>
-          <DialogHeader>
-            <DialogTitle>Edit Book</DialogTitle>
-          </DialogHeader>
-          <BookForm
-            book={book}
-            onSuccess={() => setShowEditDialog(false)}
-          />
-        </DialogContent>
-      </Dialog>
 
       {/* Delete Dialog */}
       <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>

--- a/frontend-v2/src/pages/Library.tsx
+++ b/frontend-v2/src/pages/Library.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { X } from 'lucide-react';
+import { X, Grid3x3, List, Filter } from 'lucide-react';
 import SearchBar from '@/components/SearchBar';
 import BookCard from '@/components/BookCard';
 import BooksGridSkeleton from '@/components/books/BooksGridSkeleton';
@@ -9,6 +9,7 @@ import SearchEmptyState from '@/components/SearchEmptyState';
 import BooksPagination from '@/components/books/BooksPagination';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useBooks } from '@/hooks/books/useBooks';
 import { useSearchBooks } from '@/hooks/books/useSearchBooks';
 import { useDebounce } from '@/hooks/utils/useDebounce';
@@ -32,6 +33,7 @@ const Library = () => {
   const [pageSize, setPageSize] = useState(initialPageSize);
   const [orderBy] = useState<BookOrderBy>(BookOrderBy.Added);
   const [ascending] = useState(false);
+  const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
 
   // Debounce search term
   const debouncedSearch = useDebounce(searchQuery, 300);
@@ -107,6 +109,25 @@ const Library = () => {
             <div className='flex-1 max-w-2xl'>
               <SearchBar value={searchQuery} onChange={handleSearchChange} />
             </div>
+            <div className='flex items-center gap-2'>
+              <Button
+                variant={viewMode === 'grid' ? 'default' : 'outline'}
+                size='icon'
+                onClick={() => setViewMode('grid')}
+              >
+                <Grid3x3 className='w-4 h-4' />
+              </Button>
+              <Button
+                variant={viewMode === 'list' ? 'default' : 'outline'}
+                size='icon'
+                onClick={() => setViewMode('list')}
+              >
+                <List className='w-4 h-4' />
+              </Button>
+              <Button variant='outline' size='icon'>
+                <Filter className='w-4 h-4' />
+              </Button>
+            </div>
             <Tabs
               value={selectedStatus?.toString() ?? 'all'}
               onValueChange={(v) =>
@@ -143,18 +164,46 @@ const Library = () => {
         </div>
       </header>
 
-      {/* Books Grid */}
+      {/* Books Display */}
       <div className='flex-1 overflow-auto'>
         <div className='p-6'>
           {isLoading ? (
-            <BooksGridSkeleton />
-          ) : books && books.length > 0 ? (
-            <>
-              <div className='grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-6'>
-                {books.map((book) => (
-                  <BookCard key={book.id} book={book} />
+            viewMode === 'grid' ? (
+              <BooksGridSkeleton />
+            ) : (
+              <div className='flex flex-col gap-3 max-w-4xl'>
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <div key={i} className='flex gap-4 p-4 border border-border rounded-lg'>
+                    <Skeleton className='w-24 h-36 rounded flex-shrink-0' />
+                    <div className='flex-1 space-y-3'>
+                      <Skeleton className='h-5 w-3/4' />
+                      <Skeleton className='h-4 w-1/2' />
+                      <Skeleton className='h-4 w-full' />
+                      <Skeleton className='h-4 w-full' />
+                      <div className='flex gap-2'>
+                        <Skeleton className='h-5 w-16' />
+                        <Skeleton className='h-5 w-16' />
+                      </div>
+                    </div>
+                  </div>
                 ))}
               </div>
+            )
+          ) : books && books.length > 0 ? (
+            <>
+              {viewMode === 'grid' ? (
+                <div className='grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-6'>
+                  {books.map((book) => (
+                    <BookCard key={book.id} book={book} viewMode='grid' />
+                  ))}
+                </div>
+              ) : (
+                <div className='flex flex-col gap-3 max-w-4xl'>
+                  {books.map((book) => (
+                    <BookCard key={book.id} book={book} viewMode='list' />
+                  ))}
+                </div>
+              )}
 
               {/* Pagination */}
               {totalPages && totalPages > 1 && (


### PR DESCRIPTION
… editing

Major changes:
- BookCard: Added viewMode prop to support both grid and list layouts
  - List view shows horizontal cards with description and metadata
  - Edit/delete buttons work in both modes
- Library: Added grid/list/filter toggle buttons in header
  - List view skeleton loaders for loading state
  - Conditional rendering based on viewMode
- BookDetail: Converted to inline editing
  - Edit button toggles inline form fields
  - Save/Cancel buttons replace Edit/Delete when editing
  - Removed edit dialog, keeping delete confirmation

All existing functionality preserved:
- Pagination, search, filtering, status tabs
- API integration with real hooks
- Responsive design and loading states