### PR TITLE
Implement streaming chat with book API integration

### DIFF
--- a/frontend-v2/src/hooks/chat/useStreamChat.ts
+++ b/frontend-v2/src/hooks/chat/useStreamChat.ts
@@ -1,9 +1,9 @@
 import { useState, useCallback, useRef } from 'react';
 import { streamChat } from '@/lib/chat-api';
-import type { ChatMessage } from '@/types/chat';
+import type { ChatMessage, ChatStreamChunk } from '@/types/chat';
 
 interface UseStreamChatOptions {
-  onChunk?: (content: string) => void;
+  onChunk?: (chunk: ChatStreamChunk) => void;
   onComplete?: () => void;
   onError?: (error: string) => void;
 }
@@ -33,9 +33,8 @@ export function useStreamChat() {
             break;
           }
 
-          if (chunk.Content) {
-            onChunk?.(chunk.Content);
-          }
+          // Pass the entire chunk (handles both content and tool calls)
+          onChunk?.(chunk);
 
           if (chunk.Done) {
             onComplete?.();

--- a/frontend-v2/src/types/chat.ts
+++ b/frontend-v2/src/types/chat.ts
@@ -8,9 +8,16 @@ export interface ChatRequest {
   history?: ChatMessage[];
 }
 
+export enum ChunkType {
+  Content = 0,
+  ToolCall = 1,
+}
+
 // Backend sends PascalCase properties
 export interface ChatStreamChunk {
   Content: string;
   Done: boolean;
   Error?: string;
+  Type: ChunkType;
+  ToolCallDescription?: string;
 }

--- a/src/Intellishelf.Domain/Chat/Models/ChatStreamChunk.cs
+++ b/src/Intellishelf.Domain/Chat/Models/ChatStreamChunk.cs
@@ -5,4 +5,12 @@ public class ChatStreamChunk
     public string Content { get; init; } = string.Empty;
     public bool Done { get; init; }
     public string? Error { get; init; }
+    public ChunkType Type { get; init; } = ChunkType.Content;
+    public string? ToolCallDescription { get; init; }
+}
+
+public enum ChunkType
+{
+    Content,
+    ToolCall
 }

--- a/src/Intellishelf.Domain/Chat/Services/ChatService.cs
+++ b/src/Intellishelf.Domain/Chat/Services/ChatService.cs
@@ -150,6 +150,19 @@ public class ChatService(IMcpToolsService mcpToolsService, ChatClient chatClient
                 // Execute each tool call
                 foreach (var toolCall in toolCalls)
                 {
+                    // Notify client that tool is being called with friendly description
+                    var description = ToolCallFormatter.FormatToolCall(
+                        toolCall.FunctionName,
+                        toolCall.FunctionArguments.ToString());
+
+                    yield return new ChatStreamChunk
+                    {
+                        Type = ChunkType.ToolCall,
+                        ToolCallDescription = description,
+                        Content = string.Empty,
+                        Done = false
+                    };
+
                     var toolResult = await mcpToolsService.ExecuteToolAsync(
                         userId,
                         toolCall.FunctionName,

--- a/src/Intellishelf.Domain/Chat/Services/ToolCallFormatter.cs
+++ b/src/Intellishelf.Domain/Chat/Services/ToolCallFormatter.cs
@@ -1,0 +1,43 @@
+using System.Text.Json;
+
+namespace Intellishelf.Domain.Chat.Services;
+
+/// <summary>
+/// Formats tool calls into human-friendly descriptions for display
+/// </summary>
+public static class ToolCallFormatter
+{
+    public static string FormatToolCall(string toolName, string? argumentsJson)
+    {
+        return toolName switch
+        {
+            "get_all_books" => "Looking through your library...",
+            "get_books_by_author" => FormatGetBooksByAuthor(argumentsJson),
+            _ => $"Using {toolName}..."
+        };
+    }
+
+    private static string FormatGetBooksByAuthor(string? argumentsJson)
+    {
+        if (string.IsNullOrWhiteSpace(argumentsJson))
+            return "Searching for books...";
+
+        try
+        {
+            var args = JsonSerializer.Deserialize<GetBooksByAuthorArgs>(
+                argumentsJson,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            if (args?.Author != null)
+                return $"Searching books by {args.Author}...";
+        }
+        catch
+        {
+            // Fallback if JSON parsing fails
+        }
+
+        return "Searching for books...";
+    }
+
+    private record GetBooksByAuthorArgs(string? Author);
+}


### PR DESCRIPTION
Enhances the streaming chat experience by showing when the AI is using tools (MCP) to access book data.

Backend changes:
- Extended ChatStreamChunk to include Type enum (Content/ToolCall) and ToolCallDescription
- Created ToolCallFormatter to generate human-friendly descriptions:
  * "Looking through your library..." for get_all_books
  * "Searching books by [Author]..." for get_books_by_author
- Updated ChatService to yield ToolCall chunks before executing tools

Frontend changes:
- Updated TypeScript types to match new chunk structure
- Modified useStreamChat hook to pass full chunks (not just content)
- Enhanced Chat UI to display tool calls as badges with Sparkles icon
- Messages now support "parts" array containing content and tool call indicators

UX improvements:
- Users see what's happening during "thinking" pauses
- Tool calls appear as subtle badges above assistant responses
- Descriptions are context-aware (show author name when searching by author)
- Tool indicators persist after completion for transparency