### PR TITLE
Harden MCP get_books_by_author argument parsing and add unit tests

### DIFF
--- a/Tests/Intellishelf.Unit.Tests/Api/Services/McpToolsServiceTests.cs
+++ b/Tests/Intellishelf.Unit.Tests/Api/Services/McpToolsServiceTests.cs
@@ -1,0 +1,46 @@
+using Intellishelf.Api.Mcp.Tools;
+using Intellishelf.Api.Services;
+using Intellishelf.Common.TryResult;
+using Intellishelf.Domain.Books.DataAccess;
+using Intellishelf.Domain.Books.Models;
+using Moq;
+
+namespace Intellishelf.Unit.Tests.Api.Services;
+
+public class McpToolsServiceTests
+{
+    [Fact]
+    public async Task ExecuteToolAsync_ShouldThrowInvalidOperationException_WhenGetBooksByAuthorArgumentsAreMalformedJson()
+    {
+        var service = CreateService();
+
+        var act = () => service.ExecuteToolAsync("user-1", "get_books_by_author", "{bad-json");
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(act);
+        Assert.Equal("Invalid arguments for get_books_by_author", exception.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteToolAsync_ShouldThrowInvalidOperationException_WhenGetBooksByAuthorArgumentsMissingAuthor()
+    {
+        var service = CreateService();
+
+        var act = () => service.ExecuteToolAsync("user-1", "get_books_by_author", "{}");
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(act);
+        Assert.Equal("Missing required 'author' argument for get_books_by_author", exception.Message);
+    }
+
+    private static McpToolsService CreateService()
+    {
+        var bookDaoMock = new Mock<IBookDao>();
+        bookDaoMock
+            .Setup(dao => dao.GetBooksAsync(It.IsAny<string>()))
+            .ReturnsAsync(TryResult.Success<IReadOnlyCollection<Book>>(new List<Book>()));
+
+        var getAllBooksTool = new GetAllBooksTool(bookDaoMock.Object);
+        var getBooksByAuthorTool = new GetBooksByAuthorTool(bookDaoMock.Object);
+
+        return new McpToolsService(getAllBooksTool, getBooksByAuthorTool);
+    }
+}

--- a/src/Intellishelf.Api/Services/McpToolsService.cs
+++ b/src/Intellishelf.Api/Services/McpToolsService.cs
@@ -52,8 +52,19 @@ public class McpToolsService(GetAllBooksTool getAllBooksTool, GetBooksByAuthorTo
 
     private async Task<string> ExecuteGetBooksByAuthorAsync(string userId, string argumentsJson)
     {
-        var args = JsonSerializer.Deserialize<GetBooksByAuthorArgs>(argumentsJson, new JsonSerializerOptions{ PropertyNameCaseInsensitive = true})
-            ?? throw new InvalidOperationException("Invalid arguments for get_books_by_author");
+        GetBooksByAuthorArgs args;
+        try
+        {
+            args = JsonSerializer.Deserialize<GetBooksByAuthorArgs>(argumentsJson, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+                ?? throw new InvalidOperationException("Invalid arguments for get_books_by_author");
+        }
+        catch (JsonException)
+        {
+            throw new InvalidOperationException("Invalid arguments for get_books_by_author");
+        }
+
+        if (string.IsNullOrWhiteSpace(args.Author))
+            throw new InvalidOperationException("Missing required 'author' argument for get_books_by_author");
 
         var books = await getBooksByAuthorTool.GetBooksByAuthor(userId, args.Author);
         return JsonSerializer.Serialize(books);


### PR DESCRIPTION
### Motivation
- Prevent malformed or incomplete `get_books_by_author` payloads from causing raw JSON parsing failures and ensure predictable tool-level errors when `author` is missing or blank.

### Description
- Catch `JsonException` and convert parsing failures into `InvalidOperationException` with message `"Invalid arguments for get_books_by_author"` in `src/Intellishelf.Api/Services/McpToolsService.cs`.
- Add explicit validation to throw `InvalidOperationException` with message `"Missing required 'author' argument for get_books_by_author"` when `author` is null/empty.
- Add unit tests covering malformed JSON and missing `author` at `Tests/Intellishelf.Unit.Tests/Api/Services/McpToolsServiceTests.cs`.

### Testing
- Added focused unit tests but they were not executed in this environment because `dotnet test` could not run due to missing `dotnet` (`bash: command not found: dotnet`).
- No automated tests completed here; tests are present and ready to run with `dotnet test Tests/Intellishelf.Unit.Tests/Intellishelf.Unit.Tests.csproj` in a .NET-capable environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69909e75d1a4832a942778b773a1cc4f)